### PR TITLE
[NestedGroups] Reset nesting to 1 on describe block

### DIFF
--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -95,6 +95,10 @@ module RuboCop
           (block (send nil {#{ExampleGroups::ALL.to_node_pattern}} ...) (args) ...)
         PATTERN
 
+        def_node_matcher :valid_describe?, <<-PATTERN
+          (block (send nil {:describe :xdescribe :fdescribe} ...) (args) ...)
+        PATTERN
+
         def on_block(node)
           describe, = described_constant(node)
           return unless describe
@@ -108,10 +112,11 @@ module RuboCop
 
         def find_nested_contexts(node, nesting: 1, &block)
           find_contexts(node) do |nested_context|
-            yield(nested_context) if nesting > max_nesting
+            context_nesting = valid_describe?(nested_context) ? 1 : nesting
+            yield(nested_context) if context_nesting > max_nesting
 
             nested_context.each_child_node do |child|
-              find_nested_contexts(child, nesting: nesting + 1, &block)
+              find_nested_contexts(child, nesting: context_nesting + 1, &block)
             end
           end
         end

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -6,6 +6,14 @@ describe RuboCop::Cop::RSpec::NestedGroups, :config do
   it 'flags nested contexts' do
     expect_violation(<<-RUBY)
       describe MyClass do
+        describe '#foobar' do
+          context 'when boop' do
+            context 'when bap' do
+            ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded
+            end
+          end
+        end
+
         context 'when foo' do
           context 'when bar' do
           ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded


### PR DESCRIPTION
PR that introduced the cop: https://github.com/backus/rubocop-rspec/pull/156
Issue that spawned the idea of the cop: https://github.com/backus/rubocop-rspec/issues/177

I recently updated to the newest `rubocop-rspec` and ran into a problem of rapidly triggering this cop when having a nested `describe` for my methods. For example, it would trigger:

```
describe MyClass do
  describe '#foobar' do
    context 'when boop' do
    ^^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded
    end
  end
end
```

which I don't think is a legitimate case.

@mockdeep 's original comment:

> It's generally a code smell when the nesting has to go deeper than 1

While I agree that nesting should be limited, I also _think_ that it should only start counting at the very nearest `describe` block (but I might be mistaken).
