### PR TITLE
Recommend 'be(nil)' over 'eql(nil)'

### DIFF
--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -4,7 +4,7 @@ module RuboCop
       # Check for expectations where `be(...)` can replace `eql(...)`.
       #
       # The `be` matcher compares by identity while the `eql` matcher
-      # compares using `eql?`. Integers, floats, booleans, and symbols
+      # compares using `eql?`. Integers, floats, booleans, symbols, and nil
       # can be compared by identity and therefore the `be` matcher is
       # preferable as it is a more strict test.
       #
@@ -16,6 +16,7 @@ module RuboCop
       #   expect(foo).to eql(true)
       #   expect(foo).to eql(false)
       #   expect(foo).to eql(:bar)
+      #   expect(foo).to eql(nil)
       #
       #   # good
       #   expect(foo).to be(1)
@@ -23,6 +24,7 @@ module RuboCop
       #   expect(foo).to be(true)
       #   expect(foo).to be(false)
       #   expect(foo).to be(:bar)
+      #   expect(foo).to be(nil)
       #
       # This cop only looks for instances of `expect(...).to eql(...)`. We
       # do not check `to_not` or `not_to` since `!eql?` is more strict
@@ -38,7 +40,7 @@ module RuboCop
         MSG = 'Prefer `be` over `eql`'.freeze
 
         def_node_matcher :eql_type_with_identity, <<-PATTERN
-          (send _ :to $(send nil :eql {true false int float sym}))
+          (send _ :to $(send nil :eql {true false int float sym nil_type?}))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -35,6 +35,13 @@ describe RuboCop::Cop::RSpec::BeEql do
     RUBY
   end
 
+  it 'registers an offense for `eql` when argument is nil' do
+    expect_violation(<<-RUBY)
+      it { expect(foo).to eql(nil) }
+                          ^^^ Prefer `be` over `eql`
+    RUBY
+  end
+
   it 'does not register an offense for `eql` when argument is a string' do
     expect_no_violations(<<-RUBY)
       it { expect(foo).to eql('foo') }


### PR DESCRIPTION
Fixes #217.

I couldn’t find any documentation on how to use `def_node_matcher`, and I don’t know if the `nil_type?` makes sense. But the specs are passing…