### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Master (unreleased)
 
-* Optinally ignore method names in the `describe` argument when running the `FilePath` cop. ([@bquorning][])
+## 1.8.0 (2016-10-27)
+
+* Optionally ignore method names in the `describe` argument when running the `FilePath` cop. ([@bquorning][])
 * Fix regression in how `FilePath` converts alphanumeric class names into paths. ([@bquorning][])
 * Add `ImplicitExpect` cop for enforcing `should` vs. `is_expected.to`. ([@backus][])
 * Disable `MessageExpectation` cop in the default configuration. ([@bquorning][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.7.0'.freeze
+      STRING = '1.8.0'.freeze
     end
   end
 end


### PR DESCRIPTION
Cutting a new minor version of rubocop-rspec.