### PR TITLE
Refactor DescriptionExtractor to decorate yardoc

### DIFF
--- a/bin/build_config
+++ b/bin/build_config
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 
 require 'yard'
 
+require 'rubocop-rspec'
 require 'rubocop/rspec/description_extractor'
 require 'rubocop/rspec/config_formatter'
 


### PR DESCRIPTION
I found that the description extractor was mainly speaking in terms of predicates that passed around the YARD code object. This seems like a smell so this is an attempt to wrap this logic up into an instance.