### PR TITLE
Extract RuboCop::RSpec::{Example,ExampleGroup}

### DIFF
--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -11,6 +11,8 @@ require 'rubocop/rspec/wording'
 require 'rubocop/rspec/util'
 require 'rubocop/rspec/language'
 require 'rubocop/rspec/language/node_pattern'
+require 'rubocop/rspec/example_group'
+require 'rubocop/rspec/example'
 require 'rubocop/cop/rspec/cop'
 
 RuboCop::RSpec::Inject.defaults!

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -28,26 +28,13 @@ module RuboCop
       #     end
       #
       class RepeatedDescription < Cop
-        def_node_matcher :example, <<-PATTERN
-          (block $(send _ #{Examples::ALL.node_pattern_union} str ...) ...)
-        PATTERN
-
-        # @!method scope_change?(node)
-        #
-        #   Detect if the node is an example group or shared example
-        #
-        #   Selectors which indicate that we should stop searching
-        #
-        def_node_matcher :scope_change?,
-                         (ExampleGroups::ALL + SharedGroups::ALL).block_pattern
-
         MSG = "Don't repeat descriptions within an example group.".freeze
 
         def on_block(node)
           return unless example_group?(node)
 
-          repeated_descriptions(node).each do |repeated_hook|
-            add_offense(repeated_hook, :expression)
+          repeated_descriptions(node).each do |repeated_description|
+            add_offense(repeated_description, :expression)
           end
         end
 
@@ -55,31 +42,16 @@ module RuboCop
 
         # Select examples in the current scope with repeated description strings
         def repeated_descriptions(node)
-          examples_in_scope(node)    # Select examples in example group
-            .group_by(&:method_args) # Group examples by description string
-            .values                  # Reduce to array of grouped examples
-            .reject(&:one?)          # Reject groups with only one example
-            .flatten                 # Flatten down to array of offending nodes
-        end
+          grouped_examples =
+            RuboCop::RSpec::ExampleGroup.new(node)
+              .examples
+              .group_by(&:doc_string)
 
-        def examples_in_scope(node, &block)
-          return to_enum(__method__, node) unless block_given?
-
-          node.each_child_node { |child| find_examples(child, &block) }
-        end
-
-        # Recursively search for examples within the current scope
-        #
-        # Searches node for examples and halts when a scope change is detected
-        #
-        # @param node [RuboCop::Node] node to recursively search for examples
-        #
-        # @yield [RuboCop::Node] discovered example nodes
-        def find_examples(node, &block)
-          return if scope_change?(node)
-
-          example(node, &block)
-          examples_in_scope(node, &block)
+          grouped_examples
+            .select { |description, group| description && group.size > 1 }
+            .values
+            .flatten
+            .map(&:definition)
         end
       end
     end

--- a/lib/rubocop/rspec/example.rb
+++ b/lib/rubocop/rspec/example.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module RSpec
+    # Wrapper for RSpec examples
+    class Example
+      extend RuboCop::NodePattern::Macros
+
+      def_node_matcher :extract_doc_string,     '(send _ _ $str ...)'
+      def_node_matcher :extract_metadata,       '(send _ _ _ $...)'
+      def_node_matcher :extract_implementation, '(block send args $_)'
+
+      def initialize(node)
+        @node = node
+      end
+
+      def doc_string
+        extract_doc_string(definition)
+      end
+
+      def metadata
+        extract_metadata(definition)
+      end
+
+      def implementation
+        extract_implementation(node)
+      end
+
+      def eql?(other)
+        node.eql?(other.node)
+      end
+
+      alias == eql?
+
+      def hash
+        [self.class, node].hash
+      end
+
+      def to_node
+        node
+      end
+
+      def definition
+        if node.send_type?
+          node
+        else
+          node.children.first
+        end
+      end
+
+      protected
+
+      attr_reader :node
+    end
+  end
+end

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module RSpec
+    # Wrapper for RSpec example groups
+    class ExampleGroup
+      include Language
+      extend NodePattern::Macros
+
+      def_node_matcher :example?, Examples::ALL.block_pattern
+
+      # @!method scope_change?(node)
+      #
+      #   Detect if the node is an example group or shared example
+      #
+      #   Selectors which indicate that we should stop searching
+      #
+      def_node_matcher :scope_change?,
+                       (ExampleGroups::ALL + SharedGroups::ALL).block_pattern
+
+      def initialize(node)
+        @node = node
+      end
+
+      def examples
+        examples_in_scope(node).map(&Example.public_method(:new))
+      end
+
+      private
+
+      attr_reader :node
+
+      def examples_in_scope(node)
+        node.each_child_node.flat_map do |child|
+          find_examples(child)
+        end
+      end
+
+      # Recursively search for examples within the current scope
+      #
+      # Searches node for examples and halts when a scope change is detected
+      #
+      # @param node [RuboCop::Node] node to recursively search for examples
+      #
+      # @return [Array<RuboCop::Node>] discovered example nodes
+      def find_examples(node)
+        return [] if scope_change?(node)
+
+        if example?(node)
+          [node]
+        else
+          examples_in_scope(node)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/rspec/example_group_spec.rb
+++ b/spec/rubocop/rspec/example_group_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::RSpec::ExampleGroup do
+  include RuboCop::Sexp
+
+  subject(:group) { described_class.new(parse_source(source).ast) }
+
+  let(:source) do
+    <<-RUBY
+    RSpec.describe Foo do
+      it 'does x' do
+        x
+      end
+
+      it 'does y' do
+        y
+      end
+
+      context 'nested' do
+        it 'does z' do
+          z
+        end
+      end
+    end
+    RUBY
+  end
+
+  let(:example_nodes) do
+    [
+      s(:block,
+        s(:send, nil, :it,
+          s(:str, 'does x')),
+        s(:args), s(:send, nil, :x)),
+      s(:block,
+        s(:send, nil, :it,
+          s(:str, 'does y')),
+        s(:args), s(:send, nil, :y))
+    ].map { |node| RuboCop::RSpec::Example.new(node) }
+  end
+
+  it 'exposes examples in scope' do
+    expect(group.examples).to eql(example_nodes)
+  end
+end

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::RSpec::Example do
+  include RuboCop::Sexp
+
+  def example(source)
+    described_class.new(parse_source(source).ast)
+  end
+
+  it 'extracts doc string' do
+    expect(example("it('does x') { foo }").doc_string)
+      .to eql(s(:str, 'does x'))
+  end
+
+  it 'extracts doc string for unimplemented examples' do
+    expect(example("it('does x')").doc_string)
+      .to eql(s(:str, 'does x'))
+  end
+
+  it 'returns nil for examples without doc strings' do
+    expect(example('it { foo }').doc_string).to be(nil)
+  end
+
+  it 'extracts keywords' do
+    expect(example("it('foo', :bar, baz: :qux) { a }").metadata)
+      .to eql([s(:sym, :bar), s(:hash, s(:pair, s(:sym, :baz), s(:sym, :qux)))])
+  end
+
+  it 'extracts implementation' do
+    expect(example('it("foo") { bar; baz }').implementation)
+      .to eql(s(:begin, s(:send, nil, :bar), s(:send, nil, :baz)))
+  end
+
+  it 'returns node' do
+    node = s(:sym, :node)
+    expect(described_class.new(node).to_node).to be(node)
+  end
+
+  context 'value object semantics' do
+    it 'compares by value' do # rubocop:disable RSpec/MultipleExpectations
+      aggregate_failures 'equality semantics' do
+        expect(example('it("foo")')).to eq(example('it("foo")'))
+        expect(example('it("foo")')).not_to eq(example('it("bar")'))
+      end
+    end
+
+    it 'can be used as a key in a hash' do
+      hash = {}
+
+      hash[example('it("foo")')] = 123
+
+      expect(hash[example('it("foo")')]).to be(123)
+    end
+
+    it 'computes #hash based on class and node' do
+      node = s(:node)
+
+      expect(described_class.new(node).hash)
+        .to eql([described_class, node].hash)
+    end
+  end
+end


### PR DESCRIPTION
These objects wrap RuboCop::Node objects in order to unify traversal and also clarify how certain nodes are being accessed.

I've extracted this refactor from #261 which needed a lot of the same code that `RepeatedDescription` depended on.