### PR TITLE
Bump version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+## 1.9.0 (2016-12-29)
+
 * Add `MessageSpies` cop for enforcing consistent style of either `expect(...).to have_received` or `expect(...).to receive`, intended as a replacement for the `MessageExpectation` cop. ([@bquorning][])
 * Fix `DescribeClass` to not flag `describe` at the top of a block of shared examples. ([@clupprich][])
 * Add `SingleArgumentMessageChain` cop for recommending use of `receive` instead of `receive_message_chain` where possible. ([@bquorning][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.8.0'.freeze
+      STRING = '1.9.0'.freeze
     end
   end
 end


### PR DESCRIPTION
Cutting a new minor version of rubocop-rspec.
