### PR TITLE
Autocorrect in SingleArgumentMessageChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (unreleased)
 
 * Fix internal dependencies on RuboCop to be compatible with 0.47 release. ([@backus][])
+* Add autocorrect support for `SingleArgumentMessageChain` cop. ([@bquorning][])
 
 ## 1.9.1 (2017-01-02)
 

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -27,6 +27,16 @@ module RuboCop
           add_offense(node, :selector, message(method_name))
         end
 
+        def autocorrect(node)
+          _receiver, method_name, *_args = *node
+          lambda do |corrector|
+            corrector.replace(
+              node.loc.selector,
+              method_name.equal?(:receive_message_chain) ? 'receive' : 'stub'
+            )
+          end
+        end
+
         private
 
         def multi_argument_string?(args)

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -58,8 +58,8 @@ describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     it 'reports single-argument string calls' do
       expect_violation(<<-RUBY)
         before do
-          allow(foo).to stub_chain("one") { :two }
-                        ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument
+          foo.stub_chain("one") { :two }
+              ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument
         end
       RUBY
     end
@@ -67,7 +67,7 @@ describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     it 'accepts multi-argument string calls' do
       expect_no_violations(<<-RUBY)
         before do
-          allow(foo).to stub_chain("one.two") { :three }
+          foo.stub_chain("one.two") { :three }
         end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -11,6 +11,12 @@ describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
       RUBY
     end
 
+    include_examples(
+      'autocorrect',
+      'before { allow(foo).to receive_message_chain(:one) { :two } }',
+      'before { allow(foo).to receive(:one) { :two } }'
+    )
+
     it 'accepts multi-argument calls' do
       expect_no_violations(<<-RUBY)
         before do
@@ -27,6 +33,12 @@ describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
         end
       RUBY
     end
+
+    include_examples(
+      'autocorrect',
+      'before { allow(foo).to receive_message_chain("one") { :two } }',
+      'before { allow(foo).to receive("one") { :two } }'
+    )
 
     it 'accepts multi-argument string calls' do
       expect_no_violations(<<-RUBY)
@@ -47,6 +59,12 @@ describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
       RUBY
     end
 
+    include_examples(
+      'autocorrect',
+      'before { foo.stub_chain(:one) { :two } }',
+      'before { foo.stub(:one) { :two } }'
+    )
+
     it 'accepts multi-argument calls' do
       expect_no_violations(<<-RUBY)
         before do
@@ -63,6 +81,12 @@ describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
         end
       RUBY
     end
+
+    include_examples(
+      'autocorrect',
+      'before { foo.stub_chain("one") { :two } }',
+      'before { foo.stub("one") { :two } }'
+    )
 
     it 'accepts multi-argument string calls' do
       expect_no_violations(<<-RUBY)


### PR DESCRIPTION
When running the new `SingleArgumentMessageChain` cop I realised that autocorrect should be really simple to implement. It was.

1st commit cleans up a couple of copy/paste errors in the specs.