### PR TITLE
Change MultipleExpectations to use 'Max' literal

### DIFF
--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -77,7 +77,7 @@ module RuboCop
         end
 
         def max_expectations
-          Integer(cop_config.fetch(parameter_name, 1))
+          Integer(cop_config.fetch('Max', 1))
         end
       end
     end


### PR DESCRIPTION
Previously, MultipleExpectations depended on ConfigurableMax defining the method `parameter_name`. This method name changed on the most recent (unreleased) version of rubocop and this broke the cop. Probably safer for us to rely on the literal until the public API for rubocop is clear