### PR TITLE
Fix broken reference to RuboCop::Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Fix internal dependencies on RuboCop to be compatible with 0.47 release. ([@backus][])
+
 ## 1.9.1 (2017-01-02)
 
 * Fix unintentional regression change in `NestedGroups` reported in #270. ([@backus][])

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -54,7 +54,7 @@ module RuboCop
         def find_constant_usage(node, described_class, &block)
           yield(node) if node.eql?(described_class)
 
-          return unless node.instance_of?(Node)
+          return unless node.is_a?(Parser::AST::Node)
           return if scope_change?(node) || node.const_type?
 
           node.children.each do |child|

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -60,7 +60,7 @@ module RuboCop
         private
 
         def subject_usage(node, &block)
-          return unless node.instance_of?(Node)
+          return unless node.is_a?(Parser::AST::Node)
 
           unnamed_subject(node, &block)
 

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
   end
 
   let(:fake_cop) do
-    Class.new(described_class) do
+    stub_const('RuboCop::RSpec', Module.new)
+    # rubocop:disable ClassAndModuleChildren
+    class RuboCop::RSpec::FakeCop < described_class
       def self.name
         'RuboCop::RSpec::FakeCop'
       end
@@ -29,6 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
         add_offense(node, :expression, 'I flag everything')
       end
     end
+    RuboCop::RSpec::FakeCop
   end
 
   let(:rspec_patterns) { ['_spec.rb$', '(?:^|/)spec/'] }

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
   def stub_cop_const(name)
     stub_const(
       "RuboCop::Cop::RSpec::#{name}",
-      Class.new(RuboCop::Cop::Cop)
+      Class.new(RuboCop::Cop.const_get(:WorkaroundCop))
     )
   end
 

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::RSpec::Example do
 
   it 'extracts keywords' do
     expect(example("it('foo', :bar, baz: :qux) { a }").metadata)
-      .to eql([s(:sym, :bar), s(:hash, s(:pair, s(:sym, :baz), s(:sym, :qux)))])
+      .to eq([s(:sym, :bar), s(:hash, s(:pair, s(:sym, :baz), s(:sym, :qux)))])
   end
 
   it 'extracts implementation' do


### PR DESCRIPTION
See #279. Not closing that issue since I want to run rubocop-rspec against a larger corpus first