### PR TITLE
Show actual/max value in multiple expectations cop

### DIFF
--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -48,7 +48,7 @@ module RuboCop
       class MultipleExpectations < Cop
         include ConfigurableMax
 
-        MSG = 'Too many expectations.'.freeze
+        MSG = 'Example has too many expectations [%{total}/%{max}]'.freeze
 
         def_node_matcher :example?, Examples::ALL.block_pattern
 

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       expect_violation(<<-RUBY)
         describe Foo do
           it 'uses expect twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^ Too many expectations.
+          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -53,7 +53,7 @@ describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       expect_violation(<<-RUBY)
         describe Foo do
           it 'uses expect three times' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Too many expectations.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2]
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
             expect(qux).to eq(bar)


### PR DESCRIPTION
Following #189 I've added the total/max to `MultipleExpectations`, using the same format as in `ExampleLength`. This leaves `NestedGroups` the only cop not to provide this information, but as it adds the offence as soon as the max value is exceeded, it can't use the same format. If there is a suggestion how to implement this for `NestedGroups`, I'd be happy to open a PR for it as well