### PR TITLE
Fix false negative for RSpec/MessageSpies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (unreleased)
 
+* Fix false negative for `RSpec/MessageSpies` cop. ([@onk][])
 * Fix internal dependencies on RuboCop to be compatible with 0.47 release. ([@backus][])
 * Add autocorrect support for `SingleArgumentMessageChain` cop. ([@bquorning][])
 * Rename `NestedGroups`' configuration key from `MaxNesting` to `Max` in order to be consistent with other cop configuration. ([@backus][])
@@ -166,3 +167,4 @@
 [@baberthal]: https://github.com/baberthal
 [@jeffreyc]: https://github.com/jeffreyc
 [@clupprich]: https://github.com/clupprich
+[@onk]: https://github.com/onk

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -36,7 +36,7 @@ module RuboCop
         SUPPORTED_STYLES = %w(have_received receive).freeze
 
         def_node_matcher :message_expectation, %(
-          (send (send nil :expect (send nil $_)) :to ...)
+          (send (send nil :expect $(...)) {:to :to_not :not_to} ...)
         )
 
         def_node_search :receive_message, %(
@@ -70,7 +70,7 @@ module RuboCop
           when :receive
             MSG_RECEIVE
           when :have_received
-            MSG_HAVE_RECEIVED % receiver
+            MSG_HAVE_RECEIVED % receiver.source
           end
         end
       end

--- a/spec/rubocop/cop/rspec/message_spies_spec.rb
+++ b/spec/rubocop/cop/rspec/message_spies_spec.rb
@@ -8,10 +8,46 @@ describe RuboCop::Cop::RSpec::MessageSpies, :config do
       { 'EnforcedStyle' => 'have_received' }
     end
 
-    it 'flags expect(...).to receive' do
+    it 'flags expect(send).to receive' do
       expect_violation(<<-RUBY)
         expect(foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
+      RUBY
+    end
+
+    it 'flags expect(lvar).to receive' do
+      expect_violation(<<-RUBY)
+        foo = baz
+        expect(foo).to receive(:bar)
+                       ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
+      RUBY
+    end
+
+    it 'flags expect(ivar).to receive' do
+      expect_violation(<<-RUBY)
+        expect(@foo).to receive(:bar)
+                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `@foo` as a spy using `allow` or `instance_spy`.
+      RUBY
+    end
+
+    it 'flags expect(const).to receive' do
+      expect_violation(<<-RUBY)
+        expect(Foo).to receive(:bar)
+                       ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `Foo` as a spy using `allow` or `instance_spy`.
+      RUBY
+    end
+
+    it 'flags expect(...).not_to receive' do
+      expect_violation(<<-RUBY)
+        expect(foo).not_to receive(:bar)
+                           ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
+      RUBY
+    end
+
+    it 'flags expect(...).to_not receive' do
+      expect_violation(<<-RUBY)
+        expect(foo).to_not receive(:bar)
+                           ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
@@ -52,10 +88,46 @@ describe RuboCop::Cop::RSpec::MessageSpies, :config do
       { 'EnforcedStyle' => 'receive' }
     end
 
-    it 'flags expect(...).to have_received' do
+    it 'flags expect(send).to have_received' do
       expect_violation(<<-RUBY)
         expect(foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
+      RUBY
+    end
+
+    it 'flags expect(lvar).to have_received' do
+      expect_violation(<<-RUBY)
+        foo = baz
+        expect(foo).to have_received(:bar)
+                       ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
+      RUBY
+    end
+
+    it 'flags expect(ivar).to have_received' do
+      expect_violation(<<-RUBY)
+        expect(@foo).to have_received(:bar)
+                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
+      RUBY
+    end
+
+    it 'flags expect(const).to have_received' do
+      expect_violation(<<-RUBY)
+        expect(Foo).to have_received(:bar)
+                       ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
+      RUBY
+    end
+
+    it 'flags expect(...).not_to have_received' do
+      expect_violation(<<-RUBY)
+        expect(foo).not_to have_received(:bar)
+                           ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
+      RUBY
+    end
+
+    it 'flags expect(...).to_not have_received' do
+      expect_violation(<<-RUBY)
+        expect(foo).to_not have_received(:bar)
+                           ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 


### PR DESCRIPTION
RSpec/MessageSpies detect offence for

    expect(foo).to receive(:bar)

but

    expect(@foo).to receive(:bar)
    expect(Foo).to receive(:bar) 
    expect(foo.bar).to receive(:baz)

    expect(foo).to_not receive(:bar)
    expect(foo).not_to receive(:bar)

are not.