### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+## 1.10.0 (2017-01-15)
+
 * Fix false negative for `RSpec/MessageSpies` cop. ([@onk][])
 * Fix internal dependencies on RuboCop to be compatible with 0.47 release. ([@backus][])
 * Add autocorrect support for `SingleArgumentMessageChain` cop. ([@bquorning][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.9.1'.freeze
+      STRING = '1.10.0'.freeze
     end
   end
 end


### PR DESCRIPTION
RuboCop 0.47.0 is out which introduced many expected breaking
changes. This release adapts to those changes and also introduces
many new features.