### PR TITLE
Add a preferred style for not using described_class. Fixes #193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Add `EnforcedStyle` configuration for `RSpec/DescribedClass` cop. ([@Darhazer][])
+
 ## 1.10.0 (2017-01-15)
 
 * Fix false negative for `RSpec/MessageSpies` cop. ([@onk][])
@@ -172,3 +174,4 @@
 [@jeffreyc]: https://github.com/jeffreyc
 [@clupprich]: https://github.com/clupprich
 [@onk]: https://github.com/onk
+[@Darhazer]: https://github.com/Darhazer

--- a/config/default.yml
+++ b/config/default.yml
@@ -21,6 +21,10 @@ RSpec/DescribedClass:
   Description: Checks that tests use `described_class`.
   SkipBlocks: false
   Enabled: true
+  EnforcedStyle: described_class
+  SupportedStyles:
+  - described_class
+  - explicit
 
 RSpec/DescribeMethod:
   Description: Checks that the second argument to `describe` specifies a method.


### PR DESCRIPTION
@backus 

Few notes:
* I had no idea how to name the supported styles. I've chosen `explicit` as that's what you are doing when not using desrcibed_class - explicitly refer the class - but maybe that's not best as there's no `implicit` option. Unless I rename described_class to implicit.
* The implementation is as ugly as hell. Any suggestions how to improve it are more than welcome