### PR TITLE
Fix false positives of RepeatedExample with `its` examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (unreleased)
 
 * Add `EnforcedStyle` configuration for `RSpec/DescribedClass` cop. ([@Darhazer][])
+* Fix false positive for `RSpec/RepeatedExample` cop. ([@redross][])
 
 ## 1.10.0 (2017-01-15)
 
@@ -175,3 +176,4 @@
 [@clupprich]: https://github.com/clupprich
 [@onk]: https://github.com/onk
 [@Darhazer]: https://github.com/Darhazer
+[@redross]: https://github.com/redross

--- a/lib/rubocop/cop/rspec/repeated_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_example.rb
@@ -29,11 +29,21 @@ module RuboCop
         def repeated_examples(node)
           RuboCop::RSpec::ExampleGroup.new(node)
             .examples
-            .group_by { |example| [example.metadata, example.implementation] }
+            .group_by { |example| example_signature(example) }
             .values
             .reject(&:one?)
             .flatten
             .map(&:to_node)
+        end
+
+        def example_signature(example)
+          key_parts = [example.metadata, example.implementation]
+
+          if example.definition.method_name == :its
+            key_parts << example.definition.method_args
+          end
+
+          key_parts
         end
       end
     end

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -47,6 +47,15 @@ describe RuboCop::Cop::RSpec::RepeatedExample do
     RUBY
   end
 
+  it 'does not flag examples when different its arguments are used' do
+    expect_no_violations(<<-RUBY)
+      describe 'doing x' do
+        its(:x) { is_expected.to be_present }
+        its(:y) { is_expected.to be_present }
+      end
+    RUBY
+  end
+
   it 'does not flag repeated examples in different scopes' do
     expect_no_violations(<<-RUBY)
       describe 'doing x' do


### PR DESCRIPTION
RepeatedExample cop incorrectly labels different examples as
repeated since the argument passed to its is ignored, ex.:

its(:x) { is_expected.to be_present }
its(:y) { is_expected.to be_present }

Fixed by adjusting the key used for grouping if `its` is used.

cc @backus 