### PR TITLE
Extend RSpec/DescribeMethod cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix false positive in `RSpec/SingleArgumentMessageChain` cop when the single argument is a hash. ([@Darhazer][])
+* Extend functionality of `DescribeMethod` cop. ([@redross][])
 
 ## 1.15.0 (2017-05-24)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -39,7 +39,7 @@ RSpec/DescribedClass:
   - explicit
 
 RSpec/DescribeMethod:
-  Description: Checks that the second argument to `describe` specifies a method.
+  Description: Checks that describes specify methods.
   Enabled: true
 
 RSpec/DescribeSymbol:

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -3,33 +3,124 @@
 module RuboCop
   module Cop
     module RSpec
-      # Checks that the second argument to `describe` specifies a method.
+      # Checks that describes specify methods.
       #
       # @example
       #   # bad
-      #   describe MyClass, 'do something' do
+      #   describe MyClass do
+      #     describe 'flowers' do; end
+      #   end
+      #
+      #   describe MyClass, 'flowers' do
       #   end
       #
       #   # good
+      #   describe MyClass do
+      #     describe '#my_instance_method' do; end
+      #   end
+      #
+      #   describe MyClass do
+      #     describe '.my_class_method' do; end
+      #   end
+      #
       #   describe MyClass, '#my_instance_method' do
       #   end
       #
       #   describe MyClass, '.my_class_method' do
       #   end
+      #
+      # @example configuration
+      #
+      #   # .rubocop.yml
+      #   RSpec/DescribeMethod:
+      #     IgnoredDescribes:
+      #     - flowers
+      #     - stars
+      #
+      #   # bad
+      #   describe MyClass do
+      #     describe 'not_flowers_or_stars' do; end
+      #   end
+      #
+      #   describe MyClass, 'not_flowers_or_stars' do
+      #   end
+      #
+      #   # good
+      #   describe MyClass do
+      #     describe 'flowers' do; end
+      #     describe 'stars' do; end
+      #     describe '#some_method' do; end
+      #     describe '.some_class_method' do; end
+      #   end
+      #
+      #   describe MyClass, 'flowers' do
+      #   end
+      #
       class DescribeMethod < Cop
         include RuboCop::RSpec::TopLevelDescribe
         include RuboCop::RSpec::Util
 
-        MSG = 'The second argument to describe should be the method '\
-              "being tested. '#instance' or '.class'.".freeze
-
         METHOD_STRING_MATCHER = /\A[\#\.].+/
+
+        MSG = 'The second level describes should be the method '\
+                  "being tested: '#instance' or '.class'.".freeze
+        TOP_LEVEL_MSG = 'The second argument to describe should '\
+                        'be the method being tested: '\
+                        "'#instance' or '.class'.".freeze
 
         def on_top_level_describe(_node, (_, second_arg))
           return unless second_arg && second_arg.str_type?
+          return if ignored_describe?(second_arg)
           return if METHOD_STRING_MATCHER =~ one(second_arg.children)
 
-          add_offense(second_arg, :expression)
+          add_offense(second_arg, :expression, TOP_LEVEL_MSG)
+        end
+
+        def on_block(node)
+          describe, _described_class, body = described_constant(node)
+          return unless describe
+          return unless body
+
+          describe_blocks(body).each do |describe_block|
+            if describe_block.method_args.any?
+              check_describe_arguments(describe_block)
+            else
+              add_offense(describe_block, :expression, MSG)
+            end
+          end
+        end
+
+        private
+
+        def check_describe_arguments(describe_block)
+          describe_block.method_args.each do |describe_argument|
+            next if ignored_describe?(describe_argument)
+
+            unless METHOD_STRING_MATCHER =~ describe_name(describe_argument)
+              add_offense(describe_argument, :expression, MSG)
+            end
+          end
+        end
+
+        def ignored_describe?(describe_argument)
+          return true unless describe_argument.str_type?
+
+          ignored_names.include?(describe_name(describe_argument))
+        end
+
+        def describe_name(describe_argument)
+          describe_argument.children.first
+        end
+
+        def describe_blocks(node)
+          RuboCop::RSpec::ExampleGroup.new(node)
+            .example_groups
+            .select(&:describe?)
+            .map(&:to_node)
+        end
+
+        def ignored_names
+          cop_config.fetch('IgnoredDescribes', [])
         end
       end
     end

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -20,6 +20,10 @@ module RuboCop
         (block {$(send nil #{Hooks::ALL.node_pattern_union} ...)} ...)
       PATTERN
 
+      def example_groups
+        example_groups_in_scope(node).map(&ExampleGroup.public_method(:new))
+      end
+
       def examples
         examples_in_scope(node).map(&Example.public_method(:new))
       end
@@ -28,7 +32,23 @@ module RuboCop
         hooks_in_scope(node).map(&Hook.public_method(:new))
       end
 
+      def describe?
+        node.block_type? && node.method_name == :describe
+      end
+
       private
+
+      def example_groups_in_scope(node)
+        if node.block_type?
+          [node]
+        elsif node.begin_type?
+          node.each_child_node
+        else
+          []
+        end.select do |child|
+          example_group?(child)
+        end
+      end
 
       def hooks_in_scope(node)
         node.each_child_node.flat_map do |child|

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -1,32 +1,221 @@
-RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::RSpec::DescribeMethod, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'ignores describes with only a class' do
-    expect_no_violations('describe Some::Class do; end')
+  context 'when not describing a class' do
+    it 'ignores describe names' do
+      expect_no_violations(<<-RUBY)
+        describe 'garden' do
+          describe 'flowers' do; end
+          describe 'trees' do; end
+        end
+      RUBY
+    end
   end
 
-  it 'enforces non-method names' do
-    expect_violation(<<-RUBY)
-      describe Some::Class, 'nope', '.incorrect_usage' do
-                            ^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'.
+  context 'when describing a class' do
+    it 'ignores describes with only a class' do
+      expect_no_violations('describe Some::Class do; end')
+    end
+
+    it 'skips example arguments' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class do
+          it 'does something' do; end
+        end
+      RUBY
+    end
+
+    it 'skips descriptions of class and instance methods' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class do
+          describe '.perform' do; end
+          describe '#clean' do; end
+        end
+      RUBY
+    end
+
+    it 'skips included example nodes' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class do
+          include_examples 'BA::Talent::Walkthrough::WorkingHours::Step'
+        end
+      RUBY
+    end
+
+    it 'skips empty example groups' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class do
+        end
+      RUBY
+    end
+
+    it 'skips constants' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class do
+          describe Some::Class::Hooks do
+            it { is_expected.to do_stuff }
+          end
+        end
+      RUBY
+    end
+
+    context 'when ignored describe names present' do
+      let(:cop_config) do
+        { 'IgnoredDescribes' => %w[flowers stars] }
       end
-    RUBY
+
+      it 'skips ignored describes' do
+        expect_no_violations(<<-RUBY)
+          describe Some::Class do
+            describe 'flowers' do; end
+            describe 'stars' do; end
+          end
+        RUBY
+      end
+
+      it 'complains about non-method names' do
+        expect_violation(<<-RUBY)
+          describe Some::Class do
+            describe 'flowers' do; end
+            describe 'trees' do; end
+                     ^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+
+          end
+        RUBY
+      end
+
+      it 'skips ignored describe arguments' do
+        expect_no_violations(<<-RUBY)
+            describe Some::Class, 'flowers' do; end
+        RUBY
+      end
+
+      it 'complains about non-method describe arguments' do
+        expect_violation(<<-RUBY)
+            describe Some::Class, 'flowers' do; end
+            describe Some::Class, 'trees' do; end
+                                  ^^^^^^^ The second argument to describe should be the method being tested: '#instance' or '.class'.
+        RUBY
+      end
+    end
+
+    context 'when untitled describe' do
+      it 'enforces non-empty describes' do
+        expect_violation(<<-RUBY)
+          describe Some::Class do
+            describe do; end
+            ^^^^^^^^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+          end
+        RUBY
+      end
+
+      it 'correctly marks multiline describe' do
+        expect_violation(<<-RUBY)
+          describe Some::Class do
+            describe do
+            ^^^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+              it { is_expected.to do_stuff }
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when single second level describe present' do
+      it 'complains about non-method names' do
+        expect_violation(<<-RUBY)
+          describe Some::Class do
+            describe 'flowers' do; end
+                     ^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+          end
+        RUBY
+      end
+    end
+
+    context 'when multiple second level describes present' do
+      it 'complains about non-method names' do
+        expect_violation(<<-RUBY)
+          describe Some::Class do
+            describe '.perform' do; end
+            describe 'flowers' do; end
+                     ^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+          end
+        RUBY
+      end
+    end
+
+    context 'when multiple describe arguments present' do
+      it 'complains about non-method names' do
+        expect_violation(<<-RUBY)
+          describe Some::Class do
+            describe '.something', 'flowers' do
+                                   ^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+              it { is_expected.to do_stuff }
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when deeply nested class describes present' do
+      it 'complains about non-method names' do
+        expect_violation(<<-RUBY)
+          describe SomeClass do
+            describe SomeClass::SubClass do
+              describe '.perform' do; end
+              describe 'flowers' do; end
+                       ^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+            end
+          end
+        RUBY
+      end
+
+      it 'complains about non-method names passed as arguments to desribe' do
+        expect_violation(<<-RUBY)
+          describe SomeClass do
+            describe SomeClass::SubClass, '.perform' do; end
+            describe SomeClass::SubClass, 'flowers' do; end
+                                          ^^^^^^^^^ The second level describes should be the method being tested: '#instance' or '.class'.
+          end
+        RUBY
+      end
+    end
   end
 
-  it 'skips methods starting with a . or #' do
-    expect_no_violations(<<-RUBY)
-      describe Some::Class, '.asdf' do
-      end
+  context 'when description is passed as second argument to describe' do
+    it 'complains non-method names' do
+      expect_violation(<<-RUBY)
+        describe Some::Class, 'nope', '.incorrect_usage' do
+                              ^^^^^^ The second argument to describe should be the method being tested: '#instance' or '.class'.
+        end
+      RUBY
+    end
 
-      describe Some::Class, '#fdsa' do
-      end
-    RUBY
-  end
+    it 'skips methods starting with a . or #' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class, '.asdf' do
+        end
 
-  it 'skips specs not having a string second argument' do
-    expect_no_violations(<<-RUBY)
-      describe Some::Class, :config do
+        describe Some::Class, '#fdsa' do
+        end
+      RUBY
+    end
+
+    it 'skips specs not having a string second argument' do
+      expect_no_violations(<<-RUBY)
+        describe Some::Class, :config do
+        end
+      RUBY
+    end
+
+    context 'when multiple top level describes present' do
+      it 'complains about non-method names' do
+        expect_violation(<<-RUBY)
+          describe SomeClass::SubClass, '.perform' do; end
+          describe SomeClass::SubClass, 'flowers' do; end
+                                        ^^^^^^^^^ The second argument to describe should be the method being tested: '#instance' or '.class'.
+        RUBY
       end
-    RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
   subject(:cop) { described_class.new }
 
-  describe 'receive_message_chain' do
+  context 'when receive_message_chain is used' do
     it 'reports single-argument calls' do
       expect_violation(<<-RUBY)
         before do
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
   end
 
-  describe 'stub_chain' do
+  context 'when stub_chain is used' do
     it 'reports single-argument calls' do
       expect_violation(<<-RUBY)
         before do


### PR DESCRIPTION
## Description

Makes the `DescribeMethod` cop to enforce that when describing a class, the second level describes should specify method names (`#instance` or `.class`).

Allows whitelisting predefined describe names that will be ignored.

## Reasoning

The codebase I'm working on tries to follow at least some parts of the [rspec-style-guide](https://github.com/reachlocal/rspec-style-guide) and one part of it that we really like and think it helps keep specs consistent is the "Describe block naming" [rule](https://github.com/reachlocal/rspec-style-guide#describe-block-naming), which this cop tries to enforce.

This can be used to check the whole spec structure and make it as close as possible to:
```ruby
describe Class
  describe .class_method
    context X
      specs..
    context Y
  describe #instance_method
    ...
  describe #other_instance_method
    ...
``` 

Any tips on how this can be improved are greatly appreciated. cc @backus 