### PR TITLE
Add Before/After(:all) cop (take 3)

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -17,6 +17,14 @@ RSpec/BeEql:
   Description: Check for expectations where `be(...)` can replace `eql(...)`.
   Enabled: true
 
+RSpec/BeforeAfterAll:
+  Description: Check that before/after(:all) isn't being used.
+  Enabled: true
+  Exclude:
+  - spec/spec_helper.rb
+  - spec/rails_helper.rb
+  - spec/support/**/*.rb
+
 RSpec/DescribeClass:
   Description: Check that the first argument to the top level describe is a constant.
   Enabled: true

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -23,6 +23,7 @@ RuboCop::RSpec::Inject.defaults!
 require 'rubocop/cop/rspec/any_instance'
 require 'rubocop/cop/rspec/around_block'
 require 'rubocop/cop/rspec/be_eql'
+require 'rubocop/cop/rspec/before_after_all'
 require 'rubocop/cop/rspec/describe_class'
 require 'rubocop/cop/rspec/describe_method'
 require 'rubocop/cop/rspec/described_class'

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Check that before/after(:all) isn't being used.
+      #
+      # @example
+      #   # bad
+      #   #
+      #   # Faster but risk of state leaking between examples
+      #   #
+      #   describe MyClass do
+      #     before(:all) { Widget.create }
+      #     after(:all) { Widget.delete_all }
+      #   end
+      #
+      #   # good
+      #   #
+      #   # Slower but examples are properly isolated
+      #   #
+      #   describe MyClass do
+      #     before(:each) { Widget.create }
+      #     after(:each) { Widget.delete_all }
+      #   end
+      class BeforeAfterAll < Cop
+        MESSAGE = 'Beware of using `before/after(:all)` as it may cause state '\
+          'to leak between tests. If you are using rspec-rails, and '\
+          '`use_transactional_fixtures` is enabled, then records created in '\
+          '`before(:all)` are not rolled back.'.freeze
+
+        BEFORE_AFTER_METHODS = [
+          :before,
+          :after
+        ].freeze
+
+        ALL_PAIR = s(:sym, :all)
+        CONTEXT_PAIR = s(:sym, :context)
+
+        def on_send(node)
+          _receiver, method_name, *args = *node
+          return unless BEFORE_AFTER_METHODS.include?(method_name)
+          return unless args.include?(ALL_PAIR) || args.include?(CONTEXT_PAIR)
+
+          add_offense(node, :expression, MESSAGE)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -1,0 +1,92 @@
+describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'when offenses detected' do
+    let(:code) do
+      [
+        'describe MyClass do',
+        '  before(:all) { do_something}',
+        '  after(:all) { do_something_else }',
+        'end'
+      ]
+    end
+
+    let(:expected_error) do
+      'Beware of using `before/after(:all)` as it may cause state to leak '\
+        'between tests. If you are using rspec-rails, and '\
+        '`use_transactional_fixtures` is enabled, then records created in '\
+        '`before(:all)` are not rolled back.'
+    end
+
+    it 'reports 2 offenses' do
+      inspect_source(cop, code, 'foo_spec.rb')
+      expect(cop.offenses.size).to eq(2)
+    end
+
+    it 'reports the lines for these offenses' do
+      inspect_source(cop, code, 'foo_spec.rb')
+      expect(cop.offenses.map(&:line).sort).to eq([2, 3])
+    end
+
+    it 'describes the offenses' do
+      inspect_source(cop, code, 'foo_spec.rb')
+      expect(cop.messages).to eq([expected_error, expected_error])
+    end
+  end
+
+  it 'complains for :context' do
+    inspect_source(
+      cop,
+      [
+        'describe MyClass do',
+        '  before(:context) { do_something }',
+        '  after(:context) { do_something_else }',
+        'end'
+      ],
+      'foo_spec.rb'
+    )
+    expect(cop.offenses.size).to eq(2)
+  end
+
+  it 'does not complain for before/after :each' do
+    inspect_source(
+      cop,
+      [
+        'describe MyClass do',
+        '  before(:each) { do_something }',
+        '  after(:each) { do_something_else }',
+        'end'
+      ],
+      'foo_spec.rb'
+    )
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not complain for before/after :example' do
+    inspect_source(
+      cop,
+      [
+        'describe MyClass do',
+        '  before(:example) { do_something }',
+        '  after(:example) { do_something_else }',
+        'end'
+      ],
+      'foo_spec.rb'
+    )
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not complain for before/after' do
+    inspect_source(
+      cop,
+      [
+        'describe MyClass do',
+        '  before { do_something }',
+        '  after { do_something_else }',
+        'end'
+      ],
+      'foo_spec.rb'
+    )
+    expect(cop.offenses).to be_empty
+  end
+end


### PR DESCRIPTION
Trying to push #252 over the line (which started with #108).

* Removed broken `Exclude` specs per https://github.com/backus/rubocop-rspec/pull/252#issuecomment-268933620
* Rebased on master

Thanks to @andyw8 and @cfabianski 