### PR TITLE
Remove extraneous namespace

### DIFF
--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -34,7 +34,7 @@ module RuboCop
       #
       class DescribedClass < Cop
         include RuboCop::RSpec::TopLevelDescribe
-        include RuboCop::Cop::ConfigurableEnforcedStyle
+        include ConfigurableEnforcedStyle
 
         DESCRIBED_CLASS = 'described_class'.freeze
         MSG             = 'Use `%s` instead of `%s`'.freeze

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -14,7 +14,7 @@ module RuboCop
       #     expect(false).not_to be_true
       #   end
       class NotToNot < Cop
-        include RuboCop::Cop::ConfigurableEnforcedStyle
+        include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%s` over `%s`'.freeze
 


### PR DESCRIPTION
- I happened to notice these Rubocop:: prefixes when I added the last
  cop. They are not necessary.