### PR TITLE
Improve rspec config

### DIFF
--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -1,4 +1,4 @@
-describe 'CHANGELOG.md' do
+RSpec.describe 'CHANGELOG.md' do
   subject(:changelog) { SpecHelper::ROOT.join('CHANGELOG.md').read }
 
   it 'has link definitions for all implicit links' do

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -1,4 +1,4 @@
-describe 'config/default.yml' do
+RSpec.describe 'config/default.yml' do
   subject(:default_config) do
     RuboCop::ConfigLoader.load_file('config/default.yml')
   end

--- a/spec/project/project_requires_spec.rb
+++ b/spec/project/project_requires_spec.rb
@@ -1,4 +1,4 @@
-describe 'Project requires' do
+RSpec.describe 'Project requires' do
   it 'alphabetizes cop requires' do
     source   = SpecHelper::ROOT.join('lib', 'rubocop-rspec.rb').read
     requires = source.split("\n").grep(%r{rubocop/cop/rspec/[^(?:cop)]})

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::AnyInstance do
+RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   subject(:cop) { described_class.new }
 
   it 'finds `allow_any_instance_of` instead of an instance double' do

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::AroundBlock do
+RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
   subject(:cop) { described_class.new }
 
   it 'finds `around` block without block arguments' do

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::BeEql do
+RSpec.describe RuboCop::Cop::RSpec::BeEql do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for `eql` when argument is a boolean' do

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
+RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when offenses detected' do

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::DescribeClass do
+RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   subject(:cop) { described_class.new }
 
   it 'checks first-line describe statements' do

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::DescribeMethod do
+RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   subject(:cop) { described_class.new }
 
   it 'ignores describes with only a class' do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::DescribedClass, :config do
+RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) do

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
+RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'flags an empty context' do

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::ExampleLength, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) { { 'Max' => 3 } }

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::ExampleWording, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'with configuration' do

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::ExpectActual, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'flags numeric literal values within expect(...)' do

--- a/spec/rubocop/cop/rspec/expect_output_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_output_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::RSpec::ExpectOutput do
+RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for overwriting $stdout within an example' do

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::FilePath, :config do
+RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
   subject(:cop) { described_class.new(config) }
 
   shared_examples 'invalid spec path' do |source, expected:, actual:|

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::Focus do
+RSpec.describe RuboCop::Cop::RSpec::Focus do
   subject(:cop) { described_class.new }
 
   # rubocop:disable RSpec/ExampleLength

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-describe RuboCop::Cop::RSpec::HookArgument, :config do
+RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) do

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
+RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when EnforcedStyle is is_expected' do

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::InstanceSpy do
+RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
   subject(:cop) { described_class.new }
 
   context 'when used with `have_received`' do

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::InstanceVariable do
+RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   subject(:cop) { described_class.new }
 
   it 'finds an instance variable inside a describe' do

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::LetSetup do
+RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   subject(:cop) { described_class.new }
 
   it 'complains when let! is used and not referenced' do

--- a/spec/rubocop/cop/rspec/message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/message_chain_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::MessageChain do
+RSpec.describe RuboCop::Cop::RSpec::MessageChain do
   subject(:cop) { described_class.new }
 
   it 'finds `receive_message_chain`' do

--- a/spec/rubocop/cop/rspec/message_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/message_expectation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::MessageExpectation, :config do
+RSpec.describe RuboCop::Cop::RSpec::MessageExpectation, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when EnforcedStyle is allow' do

--- a/spec/rubocop/cop/rspec/message_spies_spec.rb
+++ b/spec/rubocop/cop/rspec/message_spies_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::MessageSpies, :config do
+RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when EnforcedStyle is have_received' do

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::MultipleDescribes do
+RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   subject(:cop) { described_class.new }
 
   it 'finds multiple top level describes with class and method' do

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
+RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'without configuration' do

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::NestedGroups, :config do
+RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'flags nested contexts' do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::NotToNot, :config do
+RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when EnforcedStyle is `not_to`' do

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::RepeatedDescription do
+RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for repeated descriptions' do

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::RepeatedExample do
+RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for repeated example' do

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::ScatteredSetup do
+RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   subject(:cop) { described_class.new }
 
   it 'flags multiple hooks in the same example group' do

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::SharedContext do
+RSpec.describe RuboCop::Cop::RSpec::SharedContext do
   subject(:cop) { described_class.new }
 
   context 'shared_context' do

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
+RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
   subject(:cop) { described_class.new }
 
   describe 'receive_message_chain' do

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::RSpec::SubjectStub do
+RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   subject(:cop) { described_class.new }
 
   it 'complains when subject is stubbed' do

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
+RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'finds a `double` instead of an `instance_double`' do

--- a/spec/rubocop/rspec/language/selector_set_spec.rb
+++ b/spec/rubocop/rspec/language/selector_set_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::RSpec::Language::SelectorSet do
+RSpec.describe RuboCop::RSpec::Language::SelectorSet do
   subject(:selector_set) { described_class.new(%i(foo bar)) }
 
   it 'composes sets' do

--- a/spec/rubocop/rspec/util/one_spec.rb
+++ b/spec/rubocop/rspec/util/one_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::RSpec::Util, '.one' do
+RSpec.describe RuboCop::RSpec::Util, '.one' do
   let(:first)  { instance_double(Object)                          }
   let(:array)  { instance_double(Array, one?: true, first: first) }
   let(:client) { Class.new.extend(described_class)                }

--- a/spec/rubocop/rspec/wording_spec.rb
+++ b/spec/rubocop/rspec/wording_spec.rb
@@ -1,4 +1,4 @@
-describe RuboCop::RSpec::Wording do
+RSpec.describe RuboCop::RSpec::Wording do
   let(:replacements) do
     { 'have' => 'has', 'not' => 'does not' }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,16 @@ RSpec.configure do |config|
     mocks.syntax = :expect # Disable `should_receive` and `stub`
   end
 
+  # Forbid RSpec from monkey patching any of our objects
+  config.disable_monkey_patching!
+
+  # We should address configuration warnings when we upgrade
+  config.raise_errors_for_deprecations!
+
+  # RSpec gives helpful warnings when you are doing something wrong.
+  # We should take their advice!
+  config.raise_on_warning = true
+
   config.include(ExpectViolation)
 end
 


### PR DESCRIPTION
- Stops RSpec from monkey patching Object
  * Required updating all describes to use the explicit RSpec.describe
    format
- Raises errors on deprecations
- Raises errors instead of warnings for misusing RSpec