### PR TITLE
Improve AroundBlock cop

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -24,53 +24,42 @@ module RuboCop
       #     test.run
       #   end
       class AroundBlock < Cop
-        MSG_NO_ARG = 'Test object should be passed to around block'.freeze
+        MSG_NO_ARG     = 'Test object should be passed to around block'.freeze
         MSG_UNUSED_ARG = 'You should call `%<arg>s.call` ' \
-                          'or `%<arg>s.run`'.freeze
+                         'or `%<arg>s.run`'.freeze
 
-        def_node_matcher :scoped_hook, <<-PATTERN
-        (block (send nil :around (sym {:each :example})) $(args ...) ...)
+        def_node_matcher :hook, <<-PATTERN
+          (block {(send nil :around) (send nil :around {sym str})} (args $...) ...)
         PATTERN
 
-        def_node_matcher :unscoped_hook, <<-PATTERN
-        (block (send nil :around) $(args ...) ...)
+        def_node_search :find_arg_usage, <<-PATTERN
+          {(send $... {:call :run}) (send _ _ $...) (yield $...) (block-pass $...)}
         PATTERN
-
-        def_node_search :find_arg_usage, '(lvar $_)'
 
         def on_block(node)
-          hook(node) do |parameters|
-            missing_parameters(parameters) do
-              add_offense(node, :expression, MSG_NO_ARG)
-              return
-            end
-
-            unused_parameters(parameters) do |param, name|
-              add_offense(param, :expression, format(MSG_UNUSED_ARG, arg: name))
+          hook(node) do |(example_proxy)|
+            if example_proxy.nil?
+              add_no_arg_offense(node)
+            else
+              check_for_unused_proxy(node, example_proxy)
             end
           end
         end
 
         private
 
-        def missing_parameters(node)
-          yield if node.children[0].nil?
+        def add_no_arg_offense(node)
+          add_offense(node, :expression, MSG_NO_ARG)
         end
 
-        def unused_parameters(node)
-          first_arg = node.children[0]
-          param, _methods, _args = *first_arg
-          start = node.parent
+        def check_for_unused_proxy(block, proxy)
+          name, = *proxy
 
-          find_arg_usage(start) do |name|
-            return if param == name
+          find_arg_usage(block) do |usage|
+            return if usage.include?(s(:lvar, name))
           end
 
-          yield first_arg, param
-        end
-
-        def hook(node, &block)
-          scoped_hook(node, &block) || unscoped_hook(node, &block)
+          add_offense(proxy, :expression, format(MSG_UNUSED_ARG, arg: name))
         end
       end
     end

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -1,30 +1,130 @@
 RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
   subject(:cop) { described_class.new }
 
-  it 'finds `around` block without block arguments' do
-    expect_violation(<<-RUBY)
-      around do
-      ^^^^^^^^^ Test object should be passed to around block
-        do_something
-      end
-    RUBY
+  context 'when no value is yielded' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        around do
+        ^^^^^^^^^ Test object should be passed to around block
+          do_something
+        end
+      RUBY
+    end
   end
 
-  it 'finds `around` block with unused argument' do
-    expect_violation(<<-RUBY)
-      around do |test|
-                 ^^^^ You should call `test.call` or `test.run`
-        do_something
-      end
-    RUBY
+  context 'when the hook is scoped with a symbol' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        around(:each) do
+        ^^^^^^^^^^^^^^^^ Test object should be passed to around block
+          do_something
+        end
+      RUBY
+    end
   end
 
-  it 'checks the first argument of the block' do
-    expect_violation(<<-RUBY)
-      around do |test, unused|
-                 ^^^^ You should call `test.call` or `test.run`
-        unused.run
-      end
-    RUBY
+  context 'when the hook is scoped with a string' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        around('each') do
+        ^^^^^^^^^^^^^^^^^ Test object should be passed to around block
+          do_something
+        end
+      RUBY
+    end
+  end
+
+  context 'when the yielded value is unused' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        around do |test|
+                   ^^^^ You should call `test.call` or `test.run`
+          do_something
+        end
+      RUBY
+    end
+  end
+
+  context 'when two values are yielded and the first is unused' do
+    it 'registers an offense for the first argument' do
+      expect_violation(<<-RUBY)
+        around do |test, unused|
+                   ^^^^ You should call `test.call` or `test.run`
+          unused.run
+        end
+      RUBY
+    end
+  end
+
+  context 'when the yielded value is referenced but not used' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        around do |test|
+                   ^^^^ You should call `test.call` or `test.run`
+          test
+        end
+      RUBY
+    end
+  end
+
+  context 'when a method other than #run or #call is called' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        around do |test|
+                   ^^^^ You should call `test.call` or `test.run`
+          test.inspect
+        end
+      RUBY
+    end
+  end
+
+  context 'when #run is called' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        around do |test|
+          test.run
+        end
+      RUBY
+    end
+  end
+
+  context 'when #call is called' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        around do |test|
+          test.call
+        end
+      RUBY
+    end
+  end
+
+  context 'when used as a block arg' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        around do |test|
+          1.times(&test)
+        end
+      RUBY
+    end
+  end
+
+  context 'when passed to another method' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        around do |test|
+          something_that_might_run_test(test, another_arg)
+        end
+      RUBY
+    end
+  end
+
+  context 'when yielded to another block' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        around do |test|
+          foo { yield(some_arg, test) }
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- Significantly improves test coverage. This cop is now 100% mutation
  tested.
- Covers additional around scopes such as `:example` or `:context`.
- Allows string versions of scopes such as `'example'`.
- Checks that `#run` or `#call` is called on the test object, not just that
  the test argument was referenced.
- Refactors a bit of naming and test descriptions to be (hopefully) a
  bit clearer.