### PR TITLE
Refactor BeEql Cop

### DIFF
--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -41,15 +41,11 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          eql_type_with_identity(node) do |eql|
-            add_offense(eql, :selector, MSG)
-          end
+          eql_type_with_identity(node) { |eql| add_offense(eql, :selector) }
         end
 
         def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.selector, 'be')
-          end
+          ->(corrector) { corrector.replace(node.loc.selector, 'be') }
         end
       end
     end


### PR DESCRIPTION
- Removes unneeded MSG arg which is already the default.
- Uses one line block forms.

@backus: WDYT about relying on the default of grabbing `MSG`. I mainly wanted to kill the mutation (and it is simpler) but it's perhaps a minor tradeoff of relying on more rubocop magic.