### PR TITLE
Improve BeforeAfterAll Cop

### DIFF
--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -1,92 +1,50 @@
 RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'when offenses detected' do
-    let(:code) do
-      [
-        'describe MyClass do',
-        '  before(:all) { do_something}',
-        '  after(:all) { do_something_else }',
-        'end'
-      ]
-    end
+  def message(hook)
+    "Beware of using `#{hook}` as it may cause state to leak between tests. "\
+    'If you are using `rspec-rails`, and `use_transactional_fixtures` is '\
+    "enabled, then records created in `#{hook}` are not automatically rolled "\
+    'back.'
+  end
 
-    let(:expected_error) do
-      'Beware of using `before/after(:all)` as it may cause state to leak '\
-        'between tests. If you are using rspec-rails, and '\
-        '`use_transactional_fixtures` is enabled, then records created in '\
-        '`before(:all)` are not rolled back.'
-    end
-
-    it 'reports 2 offenses' do
-      inspect_source(cop, code, 'foo_spec.rb')
-      expect(cop.offenses.size).to eq(2)
-    end
-
-    it 'reports the lines for these offenses' do
-      inspect_source(cop, code, 'foo_spec.rb')
-      expect(cop.offenses.map(&:line).sort).to eq([2, 3])
-    end
-
-    it 'describes the offenses' do
-      inspect_source(cop, code, 'foo_spec.rb')
-      expect(cop.messages).to eq([expected_error, expected_error])
+  context 'when using before all' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        before(:all) { do_something }
+        ^^^^^^^^^^^^ #{message('before(:all)')}
+        before(:context) { do_something }
+        ^^^^^^^^^^^^^^^^ #{message('before(:context)')}
+      RUBY
     end
   end
 
-  it 'complains for :context' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  before(:context) { do_something }',
-        '  after(:context) { do_something_else }',
-        'end'
-      ],
-      'foo_spec.rb'
-    )
-    expect(cop.offenses.size).to eq(2)
+  context 'when using after all' do
+    it 'registers an offense' do
+      expect_violation(<<-RUBY)
+        after(:all) { do_something }
+        ^^^^^^^^^^^ #{message('after(:all)')}
+        after(:context) { do_something }
+        ^^^^^^^^^^^^^^^ #{message('after(:context)')}
+      RUBY
+    end
   end
 
-  it 'does not complain for before/after :each' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  before(:each) { do_something }',
-        '  after(:each) { do_something_else }',
-        'end'
-      ],
-      'foo_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+  context 'when using before each' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        before(:each) { do_something }
+        before(:example) { do_something }
+      RUBY
+    end
   end
 
-  it 'does not complain for before/after :example' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  before(:example) { do_something }',
-        '  after(:example) { do_something_else }',
-        'end'
-      ],
-      'foo_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'does not complain for before/after' do
-    inspect_source(
-      cop,
-      [
-        'describe MyClass do',
-        '  before { do_something }',
-        '  after { do_something_else }',
-        'end'
-      ],
-      'foo_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+  context 'when using after each' do
+    it 'does not register an offense' do
+      expect_no_violations(<<-RUBY)
+        after(:each) { do_something }
+        after(:example) { do_something }
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- User's source is reflected back in the error message.
- Uses the node matcher instead of manually destructuring.
- Refactors the tests to use the expect_violation expectations.
- Improves test coverage (100% mutest covered).