### PR TITLE
Improve DescribeMethod cop

### DIFF
--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -22,10 +22,10 @@ module RuboCop
 
         MESSAGE = 'The second argument to describe should be the method ' \
                   "being tested. '#instance' or '.class'".freeze
-        METHOD_STRING_MATCHER = /^[\#\.].+/
+        METHOD_STRING_MATCHER = /\A[\#\.].+/
 
         def on_top_level_describe(_node, (_, second_arg))
-          return unless second_arg && second_arg.type.equal?(:str)
+          return unless second_arg && second_arg.str_type?
           return if METHOD_STRING_MATCHER =~ one(second_arg.children)
 
           add_offense(second_arg, :expression, MESSAGE)


### PR DESCRIPTION
Tiny refactor.

- Slightly strengthens the regex that checks for #/. prefixed method
  names.
- Uses the convenient str_type? method.