### PR TITLE
Remove string argument support from AroundBlock

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -29,7 +29,7 @@ module RuboCop
                          'or `%<arg>s.run`'.freeze
 
         def_node_matcher :hook, <<-PATTERN
-          (block {(send nil :around) (send nil :around {sym str})} (args $...) ...)
+          (block {(send nil :around) (send nil :around sym)} (args $...) ...)
         PATTERN
 
         def_node_search :find_arg_usage, <<-PATTERN

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -23,17 +23,6 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     end
   end
 
-  context 'when the hook is scoped with a string' do
-    it 'registers an offense' do
-      expect_violation(<<-RUBY)
-        around('each') do
-        ^^^^^^^^^^^^^^^^^ Test object should be passed to around block
-          do_something
-        end
-      RUBY
-    end
-  end
-
   context 'when the yielded value is unused' do
     it 'registers an offense' do
       expect_violation(<<-RUBY)


### PR DESCRIPTION
- I mistakenly thought this was an alternate way to specify the lifetime
  hooks, but it turns out the hook will accept anything that isn't a
  symbol and ignore it. We should either only look at hooks with symbols
  or look at hooks with any arguments.

See: https://github.com/backus/rubocop-rspec/pull/341#issuecomment-284133416