### PR TITLE
Refactor ExampleWording cop

### DIFF
--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     let(:cop_config) do
       {
         'CustomTransform' => { 'have' => 'has', 'not' => 'does not' },
-        'IgnoredWords' => %w(only really)
+        'IgnoredWords'    => %w(only really)
       }
     end
 


### PR DESCRIPTION
- Replace manual destructuring with a much simpler node matcher.
- Breaks offense logic into a helper function.