### PR TITLE
Refactor VerifiedDouble cop

### DIFF
--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -25,10 +25,11 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless (name = unverified_double(node))
-          return if name.type.equal?(:sym) && cop_config['IgnoreSymbolicNames']
+          unverified_double(node) do |name|
+            return if name.sym_type? && cop_config['IgnoreSymbolicNames']
 
-          add_offense(node, :expression)
+            add_offense(node, :expression)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   end
 
   context 'when configuration does not specify IgnoreSymbolicNames' do
-    let(:cop_config) { Hash.new }
+    let(:cop_config) { {} }
 
     it 'find doubles whose name is a symbol' do
       expect_violation(<<-RUBY)


### PR DESCRIPTION
Tiny refactor.

- Use sym_type?
- Use matcher block instead of return.