### PR TITLE
Standardize cop messages

### DIFF
--- a/lib/rubocop/cop/rspec/any_instance.rb
+++ b/lib/rubocop/cop/rspec/any_instance.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     end
       #   end
       class AnyInstance < Cop
-        MESSAGE = 'Avoid stubbing using `%{method}`'.freeze
+        MSG = 'Avoid stubbing using `%{method}`.'.freeze
 
         def_node_matcher :disallowed_stub, <<-PATTERN
           (send _ ${:any_instance :allow_any_instance_of :expect_any_instance_of} ...)
@@ -29,7 +29,7 @@ module RuboCop
 
         def on_send(node)
           disallowed_stub(node) do |method|
-            add_offense(node, :expression, format(MESSAGE, method: method))
+            add_offense(node, :expression, format(MSG, method: method))
           end
         end
       end

--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -24,9 +24,9 @@ module RuboCop
       #     test.run
       #   end
       class AroundBlock < Cop
-        MSG_NO_ARG     = 'Test object should be passed to around block'.freeze
-        MSG_UNUSED_ARG = 'You should call `%<arg>s.call` ' \
-                         'or `%<arg>s.run`'.freeze
+        MSG_NO_ARG     = 'Test object should be passed to around block.'.freeze
+        MSG_UNUSED_ARG = 'You should call `%<arg>s.call` '\
+                         'or `%<arg>s.run`.'.freeze
 
         def_node_matcher :hook, <<-PATTERN
           (block {(send nil :around) (send nil :around sym)} (args $...) ...)

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -34,7 +34,7 @@ module RuboCop
       # coerce objects for comparison.
       #
       class BeEql < Cop
-        MSG = 'Prefer `be` over `eql`'.freeze
+        MSG = 'Prefer `be` over `eql`.'.freeze
 
         def_node_matcher :eql_type_with_identity, <<-PATTERN
           (send _ :to $(send nil :eql {true false int float sym nil_type?}))

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -24,11 +24,10 @@ module RuboCop
       #     after(:each) { Widget.delete_all }
       #   end
       class BeforeAfterAll < Cop
-        MESSAGE = 'Beware of using `%<hook>s` as it may cause state to leak '\
-                  'between tests. If you are using `rspec-rails`, and '\
-                  '`use_transactional_fixtures` is enabled, then records '\
-                  'created in `%<hook>s` are not automatically rolled '\
-                  'back.'.freeze
+        MSG = 'Beware of using `%<hook>s` as it may cause state to leak '\
+              'between tests. If you are using `rspec-rails`, and '\
+              '`use_transactional_fixtures` is enabled, then records created '\
+              'in `%<hook>s` are not automatically rolled back.'.freeze
 
         def_node_matcher :before_or_after_all, <<-PATTERN
           $(send _ {:before :after} (sym {:all :context}))
@@ -36,7 +35,7 @@ module RuboCop
 
         def on_send(node)
           before_or_after_all(node) do |hook|
-            add_offense(node, :expression, format(MESSAGE, hook: hook.source))
+            add_offense(node, :expression, format(MSG, hook: hook.source))
           end
         end
       end

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -20,15 +20,16 @@ module RuboCop
         include RuboCop::RSpec::TopLevelDescribe,
                 RuboCop::RSpec::Util
 
-        MESSAGE = 'The second argument to describe should be the method ' \
-                  "being tested. '#instance' or '.class'".freeze
+        MSG = 'The second argument to describe should be the method '\
+              "being tested. '#instance' or '.class'.".freeze
+
         METHOD_STRING_MATCHER = /\A[\#\.].+/
 
         def on_top_level_describe(_node, (_, second_arg))
           return unless second_arg && second_arg.str_type?
           return if METHOD_STRING_MATCHER =~ one(second_arg.children)
 
-          add_offense(second_arg, :expression, MESSAGE)
+          add_offense(second_arg, :expression)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -37,7 +37,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         DESCRIBED_CLASS = 'described_class'.freeze
-        MSG             = 'Use `%s` instead of `%s`'.freeze
+        MSG             = 'Use `%s` instead of `%s`.'.freeze
 
         def_node_matcher :common_instance_exec_closure?, <<-PATTERN
           (block (send (const nil {:Class :Module}) :new ...) ...)

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -28,6 +28,8 @@ module RuboCop
       class ExampleLength < Cop
         include CodeLength
 
+        MSG = 'Example has too many lines [%d/%d].'.freeze
+
         def on_block(node)
           return unless example?(node)
 
@@ -45,7 +47,7 @@ module RuboCop
         end
 
         def message(length)
-          format('Example has too many lines. [%d/%d]', length, max_length)
+          format(MSG, length, max_length)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   expect(name).to eq("John")
       #
       class ExpectActual < Cop
-        MSG = 'Provide the actual you are testing to `expect(...)`'.freeze
+        MSG = 'Provide the actual you are testing to `expect(...)`.'.freeze
 
         SIMPLE_LITERALS = %i(
           true

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -15,8 +15,8 @@ module RuboCop
       #   # good
       #   expect { my_app.print_report }.to output('Hello World').to_stdout
       class ExpectOutput < Cop
-        MSG = 'Use `expect { ... }.to output(...).to_%<name>s` ' \
-              'instead of mutating $%<name>s'.freeze
+        MSG = 'Use `expect { ... }.to output(...).to_%<name>s` '\
+              'instead of mutating $%<name>s.'.freeze
 
         def_node_matcher :hook?, Hooks::ALL.block_pattern
 

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -44,7 +44,7 @@ module RuboCop
       class FilePath < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MESSAGE = 'Spec path should end with `%s`'.freeze
+        MSG          = 'Spec path should end with `%s`.'.freeze
         ROUTING_PAIR = s(:pair, s(:sym, :type), s(:sym, :routing))
 
         def on_top_level_describe(node, args)
@@ -57,7 +57,7 @@ module RuboCop
           path_matcher = matcher(object, args.at(1))
           return if source_filename =~ regexp_from_glob(path_matcher)
 
-          add_offense(node, :expression, format(MESSAGE, path_matcher))
+          add_offense(node, :expression, format(MSG, path_matcher))
         end
 
         private

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -19,8 +19,8 @@ module RuboCop
       #   end
       #
       class InstanceSpy < Cop
-        MSG = 'Use `instance_spy` when you check your double ' \
-              'with `have_received`'.freeze
+        MSG = 'Use `instance_spy` when you check your double '\
+              'with `have_received`.'.freeze
 
         EXAMPLES = Examples::ALL.node_pattern_union.freeze
 
@@ -47,7 +47,7 @@ module RuboCop
 
           null_double(node) do |var, receiver|
             have_received_usage(node) do |expected|
-              add_offense(receiver, :expression, MSG) if expected == var
+              add_offense(receiver, :expression) if expected == var
             end
           end
         end

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -47,7 +47,7 @@ module RuboCop
       #   end
       #
       class InstanceVariable < Cop
-        MESSAGE = 'Use `let` instead of an instance variable'.freeze
+        MSG = 'Use `let` instead of an instance variable.'.freeze
 
         EXAMPLE_GROUP_METHODS = ExampleGroups::ALL + SharedGroups::ALL
 
@@ -63,7 +63,7 @@ module RuboCop
           ivar_usage(node) do |ivar, name|
             return if assignment_only? && !ivar_assigned?(node, name)
 
-            add_offense(ivar, :expression, MESSAGE)
+            add_offense(ivar, :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -21,8 +21,8 @@ module RuboCop
       class ItBehavesLike < Cop
         include ConfigurableEnforcedStyle
 
-        MESSAGE = 'Prefer `%s` over `%s` when including examples in '\
-                  'a nested context.'.freeze
+        MSG = 'Prefer `%s` over `%s` when including examples in '\
+              'a nested context.'.freeze
 
         def_node_matcher :example_inclusion_offense, '(send _ % ...)'
 
@@ -39,7 +39,7 @@ module RuboCop
         private
 
         def message(_node)
-          format(MESSAGE, style, alternative_style)
+          format(MSG, style, alternative_style)
         end
 
         private_constant(*constants(false))

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -27,7 +27,7 @@ module RuboCop
       #     end
       #   end
       class LeadingSubject < Cop
-        MSG = 'Declare `subject` above any other `let` declarations'.freeze
+        MSG = 'Declare `subject` above any other `let` declarations.'.freeze
 
         def_node_matcher :subject?, '(block $(send nil :subject ...) args ...)'
 

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   allow(foo).to receive(bar: thing)
       #
       class MessageChain < Cop
-        MESSAGE = 'Avoid stubbing using `%<method>s`'.freeze
+        MSG = 'Avoid stubbing using `%<method>s`.'.freeze
 
         def_node_matcher :message_chain, Matchers::MESSAGE_CHAIN.send_pattern
 
@@ -21,7 +21,7 @@ module RuboCop
         end
 
         def message(node)
-          format(MESSAGE, method: node.method_name)
+          format(MSG, method: node.method_name)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -27,11 +27,12 @@ module RuboCop
       class MessageSpies < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_RECEIVE = 'Prefer `receive` for setting message ' \
-          'expectations.'.freeze
-        MSG_HAVE_RECEIVED = 'Prefer `have_received` for setting message ' \
-          'expectations. Setup `%s` as a spy using `allow` or `instance_spy`.'
-          .freeze
+        MSG_RECEIVE = 'Prefer `receive` for setting message '\
+                      'expectations.'.freeze
+
+        MSG_HAVE_RECEIVED = 'Prefer `have_received` for setting message '\
+                            'expectations. Setup `%s` as a spy using `allow`'\
+                            ' or `instance_spy`.'.freeze
 
         SUPPORTED_STYLES = %w(have_received receive).freeze
 

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -25,7 +25,7 @@ module RuboCop
       class MultipleDescribes < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Do not use multiple top level describes - ' \
+        MSG = 'Do not use multiple top level describes - '\
               'try to nest them.'.freeze
 
         def on_top_level_describe(node, _args)

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -48,7 +48,7 @@ module RuboCop
       class MultipleExpectations < Cop
         include ConfigurableMax
 
-        MSG = 'Example has too many expectations [%{total}/%{max}]'.freeze
+        MSG = 'Example has too many expectations [%{total}/%{max}].'.freeze
 
         def_node_search :example_with_aggregated_failures?, <<-PATTERN
         (pair (sym :aggregate_failures) (true))

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -38,8 +38,8 @@ module RuboCop
       #     it { should be_valid }
       #   end
       class NamedSubject < Cop
-        MSG = 'Name your test subject if '\
-              'you need to reference it explicitly.'.freeze
+        MSG = 'Name your test subject if you need '\
+              'to reference it explicitly.'.freeze
 
         def_node_matcher :rspec_block?, <<-PATTERN
           (block

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -16,7 +16,7 @@ module RuboCop
       class NotToNot < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%s` over `%s`'.freeze
+        MSG = 'Prefer `%s` over `%s`.'.freeze
 
         def_node_matcher :not_to_not_offense, '(send _ % ...)'
 

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -51,10 +51,11 @@ module RuboCop
       #   end
       #
       class SharedContext < Cop
-        MESSAGE_EXAMPLES = "Use `shared_examples` when you don't define context"
-          .freeze
-        MESSAGE_CONTEXT = "Use `shared_context` when you don't define examples"
-          .freeze
+        MSG_EXAMPLES = "Use `shared_examples` when you don't "\
+                       'define context.'.freeze
+
+        MSG_CONTEXT  = "Use `shared_context` when you don't "\
+                       'define examples.'.freeze
 
         examples = (Examples::ALL + Includes::EXAMPLES)
         def_node_search :examples?, examples.send_pattern
@@ -67,11 +68,11 @@ module RuboCop
 
         def on_block(node)
           context_with_only_examples(node) do
-            add_shared_item_offense(node, MESSAGE_EXAMPLES)
+            add_shared_item_offense(node, MSG_EXAMPLES)
           end
 
           examples_with_only_context(node) do
-            add_shared_item_offense(node, MESSAGE_CONTEXT)
+            add_shared_item_offense(node, MSG_CONTEXT)
           end
         end
 

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -15,8 +15,8 @@ module RuboCop
       #   allow(foo).to receive("bar.baz")
       #
       class SingleArgumentMessageChain < Cop
-        MESSAGE = 'Use `%<recommended>s` instead of calling '\
-                  '`%<called>s` with a single argument'.freeze
+        MSG = 'Use `%<recommended>s` instead of calling '\
+              '`%<called>s` with a single argument.'.freeze
 
         def_node_matcher :message_chain, <<-PATTERN
           (send _ #{Matchers::MESSAGE_CHAIN.node_pattern_union} $...)
@@ -45,7 +45,7 @@ module RuboCop
         def message(node)
           method = node.method_name
 
-          format(MESSAGE, recommended: replacement(method), called: method)
+          format(MSG, recommended: replacement(method), called: method)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
     expect_violation(<<-RUBY)
       before do
         allow_any_instance_of(Object).to receive(:foo)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `allow_any_instance_of`
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `allow_any_instance_of`.
       end
     RUBY
   end
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
     expect_violation(<<-RUBY)
       before do
         expect_any_instance_of(Object).to receive(:foo)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `expect_any_instance_of`
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `expect_any_instance_of`.
       end
     RUBY
   end
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
     expect_violation(<<-RUBY)
       before do
         Object.any_instance.should_receive(:foo)
-        ^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `any_instance`
+        ^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `any_instance`.
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     it 'registers an offense' do
       expect_violation(<<-RUBY)
         around do
-        ^^^^^^^^^ Test object should be passed to around block
+        ^^^^^^^^^ Test object should be passed to around block.
           do_something
         end
       RUBY
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     it 'registers an offense' do
       expect_violation(<<-RUBY)
         around(:each) do
-        ^^^^^^^^^^^^^^^^ Test object should be passed to around block
+        ^^^^^^^^^^^^^^^^ Test object should be passed to around block.
           do_something
         end
       RUBY
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     it 'registers an offense' do
       expect_violation(<<-RUBY)
         around do |test|
-                   ^^^^ You should call `test.call` or `test.run`
+                   ^^^^ You should call `test.call` or `test.run`.
           do_something
         end
       RUBY
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     it 'registers an offense for the first argument' do
       expect_violation(<<-RUBY)
         around do |test, unused|
-                   ^^^^ You should call `test.call` or `test.run`
+                   ^^^^ You should call `test.call` or `test.run`.
           unused.run
         end
       RUBY
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     it 'registers an offense' do
       expect_violation(<<-RUBY)
         around do |test|
-                   ^^^^ You should call `test.call` or `test.run`
+                   ^^^^ You should call `test.call` or `test.run`.
           test
         end
       RUBY
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
     it 'registers an offense' do
       expect_violation(<<-RUBY)
         around do |test|
-                   ^^^^ You should call `test.call` or `test.run`
+                   ^^^^ You should call `test.call` or `test.run`.
           test.inspect
         end
       RUBY

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -4,41 +4,41 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
   it 'registers an offense for `eql` when argument is a boolean' do
     expect_violation(<<-RUBY)
       it { expect(foo).to eql(true) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(false) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is an integer' do
     expect_violation(<<-RUBY)
       it { expect(foo).to eql(0) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(123) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is a float' do
     expect_violation(<<-RUBY)
       it { expect(foo).to eql(1.0) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(1.23) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is a symbol' do
     expect_violation(<<-RUBY)
       it { expect(foo).to eql(:foo) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is nil' do
     expect_violation(<<-RUBY)
       it { expect(foo).to eql(nil) }
-                          ^^^ Prefer `be` over `eql`
+                          ^^^ Prefer `be` over `eql`.
     RUBY
   end
 

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   it 'enforces non-method names' do
     expect_violation(<<-RUBY)
       describe Some::Class, 'nope', '.incorrect_usage' do
-                            ^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'
+                            ^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'.
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
 
           before do
             MyClass
-            ^^^^^^^ Use `described_class` instead of `MyClass`
+            ^^^^^^^ Use `described_class` instead of `MyClass`.
 
             Foo.custom_block do
               MyClass
@@ -32,16 +32,16 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
         describe MyClass do
           controller(ApplicationController) do
             bar = MyClass
-                  ^^^^^^^ Use `described_class` instead of `MyClass`
+                  ^^^^^^^ Use `described_class` instead of `MyClass`.
           end
 
           before(:each) do
             MyClass
-            ^^^^^^^ Use `described_class` instead of `MyClass`
+            ^^^^^^^ Use `described_class` instead of `MyClass`.
 
             Foo.custom_block do
               MyClass
-              ^^^^^^^ Use `described_class` instead of `MyClass`
+              ^^^^^^^ Use `described_class` instead of `MyClass`.
             end
           end
         end
@@ -80,13 +80,13 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       expect_violation(<<-RUBY)
         describe MyClass do
           include MyClass
-                  ^^^^^^^ Use `described_class` instead of `MyClass`
+                  ^^^^^^^ Use `described_class` instead of `MyClass`.
 
           subject { MyClass.do_something }
-                    ^^^^^^^ Use `described_class` instead of `MyClass`
+                    ^^^^^^^ Use `described_class` instead of `MyClass`.
 
           before { MyClass.do_something }
-                   ^^^^^^^ Use `described_class` instead of `MyClass`
+                   ^^^^^^^ Use `described_class` instead of `MyClass`.
         end
       RUBY
     end
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
             subject { MyClass::Foo }
 
             let(:foo) { MyClass }
-                        ^^^^^^^ Use `described_class` instead of `MyClass`
+                        ^^^^^^^ Use `described_class` instead of `MyClass`.
           end
         end
       RUBY
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       expect_violation(<<-RUBY)
         describe MyNamespace::MyClass do
           subject { MyNamespace::MyClass }
-                    ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`
+                    ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`.
         end
       RUBY
     end
@@ -222,13 +222,13 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       expect_violation(<<-RUBY)
         describe MyClass do
           include described_class
-                  ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`
+                  ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`.
 
           subject { described_class.do_something }
-                    ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`
+                    ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`.
 
           before { described_class.do_something }
-                   ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`
+                   ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`.
         end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
     it 'flags the example' do
       expect_violation(<<-RUBY)
         it do
-        ^^^^^ Example has too many lines. [4/3]
+        ^^^^^ Example has too many lines [4/3].
           line 1
           line 2
           line 3
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
     it 'flags the example' do
       expect_violation(<<-RUBY)
         it do
-        ^^^^^ Example has too many lines. [4/3]
+        ^^^^^ Example has too many lines [4/3].
           line 1
           line 2
           # comment

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(123).to eq(bar)
-                 ^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^ Provide the actual you are testing to `expect(...)`.
           expect(12.3).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^ Provide the actual you are testing to `expect(...)`.
           expect(1i).to eq(bar)
-                 ^^ Provide the actual you are testing to `expect(...)`
+                 ^^ Provide the actual you are testing to `expect(...)`.
           expect(1r).to eq(bar)
-                 ^^ Provide the actual you are testing to `expect(...)`
+                 ^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -25,9 +25,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(true).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^ Provide the actual you are testing to `expect(...)`.
           expect(false).to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -38,9 +38,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect("foo").to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^ Provide the actual you are testing to `expect(...)`.
           expect(:foo).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(nil).to eq(bar)
-                 ^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -74,9 +74,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect([123]).to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^ Provide the actual you are testing to `expect(...)`.
           expect([[123]]).to eq(bar)
-                 ^^^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -87,9 +87,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(foo: 1, bar: 2).to eq(bar)
-                 ^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
           expect(foo: 1, bar: [{}]).to eq(bar)
-                 ^^^^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -100,9 +100,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1..2).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^ Provide the actual you are testing to `expect(...)`.
           expect(1...2).to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(/foo|bar/).to eq(bar)
-                 ^^^^^^^^^ Provide the actual you are testing to `expect(...)`
+                 ^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
         end
       end
     RUBY

--- a/spec/rubocop/cop/rspec/expect_output_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_output_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
     expect_violation(<<-RUBY)
       specify do
         $stdout = StringIO.new
-        ^^^^^^^ Use `expect { ... }.to output(...).to_stdout` instead of mutating $stdout
+        ^^^^^^^ Use `expect { ... }.to output(...).to_stdout` instead of mutating $stdout.
       end
     RUBY
   end
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
     expect_violation(<<-RUBY)
       before(:each) do
         $stderr = StringIO.new
-        ^^^^^^^ Use `expect { ... }.to output(...).to_stderr` instead of mutating $stderr
+        ^^^^^^^ Use `expect { ... }.to output(...).to_stderr` instead of mutating $stderr.
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
       end
 
       it 'adds a message saying what the path should end with' do
-        expect(cop.messages).to eql(["Spec path should end with `#{expected}`"])
+        expect(cop.messages)
+          .to eql(["Spec path should end with `#{expected}`."])
       end
     end
   end

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
       expect_violation(<<-RUBY)
         it do
           foo = instance_double(Foo).as_null_object
-                ^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`
+                ^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
           expect(foo).to have_received(:bar)
         end
       RUBY
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
       expect_violation(<<-RUBY)
         it do
           foo = instance_double(Foo, :name).as_null_object
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
           expect(foo).to have_received(:bar)
         end
       RUBY

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
       describe MyClass do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
-                    ^^^^ Use `let` instead of an instance variable
+                    ^^^^ Use `let` instead of an instance variable.
       end
     RUBY
   end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     expect_violation(<<-RUBY)
       shared_examples 'shared example' do
         it { expect(@foo).to be_empty }
-                    ^^^^ Use `let` instead of an instance variable
+                    ^^^^ Use `let` instead of an instance variable.
       end
     RUBY
   end
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
         describe MyClass do
           before { @foo = [] }
           it { expect(@foo).to be_empty }
-                      ^^^^ Use `let` instead of an instance variable
+                      ^^^^ Use `let` instead of an instance variable.
         end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
         let(:params) { foo }
 
         subject { described_class.new }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let` declarations
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let` declarations.
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/message_chain_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageChain do
     expect_violation(<<-RUBY)
       before do
         allow(foo).to receive_message_chain(:one, :two) { :three }
-                      ^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `receive_message_chain`
+                      ^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `receive_message_chain`.
       end
     RUBY
   end
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageChain do
     expect_violation(<<-RUBY)
       before do
         foo.stub_chain(:one, :two).and_return(:three)
-            ^^^^^^^^^^ Avoid stubbing using `stub_chain`
+            ^^^^^^^^^^ Avoid stubbing using `stub_chain`.
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       expect_violation(<<-RUBY)
         describe Foo do
           it 'uses expect twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]
+          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       expect_violation(<<-RUBY)
         describe Foo do
           it 'has multiple aggregate_failures calls' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
             aggregate_failures do
             end
             aggregate_failures do
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     expect_violation(<<-RUBY)
       describe Foo do
         it 'uses expect twice', aggregate_failures: false do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
           expect(foo).to eq(bar)
           expect(baz).to eq(bar)
         end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       expect_violation(<<-RUBY)
         describe Foo do
           it 'uses expect three times' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2].
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
             expect(qux).to eq(bar)

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     it 'detects the `to_not` offense' do
       expect_violation(<<-RUBY)
         it { expect(false).to_not be_true }
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to` over `to_not`
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
     end
 
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     it 'detects the `not_to` offense' do
       expect_violation(<<-RUBY)
         it { expect(false).not_to be_true }
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `to_not` over `not_to`
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
     end
 

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     it 'registers an offense for shared_context with only examples' do
       expect_violation(<<-RUBY)
         shared_context 'foo' do
-        ^^^^^^^^^^^^^^^^^^^^ Use `shared_examples` when you don't define context
+        ^^^^^^^^^^^^^^^^^^^^ Use `shared_examples` when you don't define context.
           it 'performs actions' do
           end
         end
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     it 'registers an offense for shared_examples with only let' do
       expect_violation(<<-RUBY)
         shared_examples 'foo' do
-        ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples
+        ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           let(:foo) { :bar }
         end
       RUBY
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     it 'registers an offense for shared_examples with only subject' do
       expect_violation(<<-RUBY)
         shared_examples 'foo' do
-        ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples
+        ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           subject(:foo) { :bar }
         end
       RUBY
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     it 'registers an offense for shared_examples with only hooks' do
       expect_violation(<<-RUBY)
         shared_examples 'foo' do
-        ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples
+        ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           before do
             foo
           end

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
       expect_violation(<<-RUBY)
         before do
           allow(foo).to receive_message_chain(:one) { :two }
-                        ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument
+                        ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
         end
       RUBY
     end
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
       expect_violation(<<-RUBY)
         before do
           allow(foo).to receive_message_chain("one") { :two }
-                        ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument
+                        ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
         end
       RUBY
     end
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
       expect_violation(<<-RUBY)
         before do
           foo.stub_chain(:one) { :two }
-              ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument
+              ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
         end
       RUBY
     end
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
       expect_violation(<<-RUBY)
         before do
           foo.stub_chain("one") { :two }
-              ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument
+              ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
         end
       RUBY
     end


### PR DESCRIPTION
This tries to bring a bit more consistency to the cop messages. Another
pass should be done to improve the wording, but this is something.

- All messages now end in a period, `.`.
- ALl cops with a single message constant are named MSG (I chose MSG
  over MESSAGE because it's what rubocop expects).
- Adjusted some message alignment and chose a consistent line
  continuation pattern of not having an extra space before `\`.
- Removed explicit MSG arguments where they were no longer needed.
- Lifted one message into a frozen MSG constant.
- Verified much of the above was correct with a script.