### PR TITLE
Refactor FilePath cop

### DIFF
--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  it 'allows different parent directories' do
+    expect_no_violations(<<-RUBY, filename: 'parent_dir/some/class_spec.rb')
+      describe Some::Class do; end
+    RUBY
+  end
+
   it 'handles CamelCaps class names' do
     expect_no_violations(<<-RUBY, filename: 'my_class_spec.rb')
       describe MyClass do; end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -1,242 +1,182 @@
 RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples 'invalid spec path' do |source, expected:, actual:|
-    context "when `#{source}` is defined in #{actual}" do
-      before do
-        inspect_source(cop, source, actual)
-      end
-
-      it 'flags an offense' do
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it 'registers the offense on line 1' do
-        expect(cop.offenses.map(&:line)).to eq([1])
-      end
-
-      it 'adds a message saying what the path should end with' do
-        expect(cop.messages)
-          .to eql(["Spec path should end with `#{expected}`."])
-      end
-    end
+  it 'registers an offense for a bad path' do
+    expect_violation(<<-RUBY, filename: 'wrong_path_foo_spec.rb')
+      describe MyClass, 'foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+    RUBY
   end
 
-  include_examples 'invalid spec path',
-                   "describe MyClass, 'foo' do; end",
-                   expected: 'my_class*foo*_spec.rb',
-                   actual:   'wrong_path_foo_spec.rb'
+  it 'registers an offense for a wrong class but a correct method' do
+    expect_violation(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
+      describe MyClass, '#foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+    RUBY
+  end
 
-  include_examples 'invalid spec path',
-                   "describe MyClass, '#foo' do; end",
-                   expected: 'my_class*foo*_spec.rb',
-                   actual: 'wrong_class_foo_spec.rb'
+  it 'registers an offense for a repeated .rb' do
+    expect_violation(<<-RUBY, filename: 'my_class/foo_spec.rb.rb')
+      describe MyClass, '#foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+    RUBY
+  end
 
-  include_examples 'invalid spec path',
-                   "describe MyClass, '#foo' do; end",
-                   expected: 'my_class*foo*_spec.rb',
-                   actual: 'my_class/foo_spec.rb.rb'
+  it 'registers an offense for a file missing a .rb' do
+    expect_violation(<<-RUBY, filename: 'my_class/foo_specorb')
+      describe MyClass, '#foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+    RUBY
+  end
 
-  include_examples 'invalid spec path',
-                   "describe MyClass, '#foo' do; end",
-                   expected: 'my_class*foo*_spec.rb',
-                   actual: 'my_class/foo_specorb'
+  it 'registers an offense for a wrong class and highlights metadata' do
+    expect_violation(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
+      describe MyClass, '#foo', blah: :blah do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+    RUBY
+  end
 
-  include_examples 'invalid spec path',
-                   "describe MyClass, '#foo', blah: :blah do; end",
-                   expected: 'my_class*foo*_spec.rb',
-                   actual: 'wrong_class_foo_spec.rb'
+  it 'registers an offense for a wrong class name' do
+    expect_violation(<<-RUBY, filename: 'wrong_class_spec.rb')
+      describe MyClass do; end
+      ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
+    RUBY
+  end
 
-  include_examples 'invalid spec path',
-                   'describe MyClass do; end',
-                   expected: 'my_class*_spec.rb',
-                   actual: 'wrong_class_spec.rb'
+  it 'registers an offense for a wrong class name with a symbol argument' do
+    expect_violation(<<-RUBY, filename: 'wrong_class_spec.rb')
+      describe MyClass, :foo do; end
+      ^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
+    RUBY
+  end
 
-  include_examples 'invalid spec path',
-                   'describe MyClass, :foo do; end',
-                   expected: 'my_class*_spec.rb',
-                   actual: 'wrong_class_spec.rb'
-
-  include_examples 'invalid spec path',
-                   'describe User do; end',
-                   expected: 'user*_spec.rb',
-                   actual: 'user.rb'
+  it 'registers an offense for a file missing _spec' do
+    expect_violation(<<-RUBY, filename: 'user.rb')
+      describe User do; end
+      ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
+    RUBY
+  end
 
   it 'skips specs that do not describe a class / method' do
-    inspect_source(
-      cop,
-      "describe 'Test something' do; end",
-      'some/class/spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class/spec.rb')
+      describe 'Test something' do; end
+    RUBY
   end
 
   it 'skips specs that do have multiple top level describes' do
-    inspect_source(
-      cop,
-      [
-        "describe MyClass, 'do_this' do; end",
-        "describe MyClass, 'do_that' do; end"
-      ],
-      'some/class/spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class/spec.rb')
+      describe MyClass, 'do_this' do; end
+      describe MyClass, 'do_that' do; end
+    RUBY
   end
 
   it 'checks class specs' do
-    inspect_source(
-      cop,
-      'describe Some::Class do; end',
-      'some/class_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class_spec.rb')
+      describe Some::Class do; end
+    RUBY
   end
 
   it 'handles CamelCaps class names' do
-    inspect_source(
-      cop,
-      'describe MyClass do; end',
-      'my_class_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'my_class_spec.rb')
+      describe MyClass do; end
+    RUBY
   end
 
   it 'handles ACRONYMClassNames' do
-    inspect_source(
-      cop,
-      'describe ABCOne::Two do; end',
-      'abc_one/two_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'abc_one/two_spec.rb')
+      describe ABCOne::Two do; end
+    RUBY
   end
 
   it 'handles ALLCAPS class names' do
-    inspect_source(
-      cop,
-      'describe ALLCAPS do; end',
-      'allcaps_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'allcaps_spec.rb')
+      describe ALLCAPS do; end
+    RUBY
   end
 
   it 'handles alphanumeric class names' do
-    inspect_source(
-      cop,
-      'describe IPV4AndIPV6 do; end',
-      'ipv4_and_ipv6_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'ipv4_and_ipv6_spec.rb')
+      describe IPV4AndIPV6 do; end
+    RUBY
   end
 
   it 'checks instance methods' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '#inst' do; end",
-      'some/class/inst_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class/inst_spec.rb')
+      describe Some::Class, '#inst' do; end
+    RUBY
   end
 
   it 'checks class methods' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '.inst' do; end",
-      'some/class/inst_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class/inst_spec.rb')
+      describe Some::Class, '.inst' do; end
+    RUBY
   end
 
   it 'allows flat hierarchies for instance methods' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '#inst' do; end",
-      'some/class_inst_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class_inst_spec.rb')
+      describe Some::Class, '#inst' do; end
+    RUBY
   end
 
   it 'allows flat hierarchies for class methods' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '.inst' do; end",
-      'some/class_inst_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class_inst_spec.rb')
+      describe Some::Class, '.inst' do; end
+    RUBY
   end
 
   it 'allows subdirs for instance methods' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '#inst' do; end",
-      'some/class/instance_methods/inst_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    filename = 'some/class/instance_methods/inst_spec.rb'
+    expect_no_violations(<<-RUBY, filename: filename)
+      describe Some::Class, '#inst' do; end
+    RUBY
   end
 
   it 'allows subdirs for class methods' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '.inst' do; end",
-      'some/class/class_methods/inst_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    filename = 'some/class/class_methods/inst_spec.rb'
+    expect_no_violations(<<-RUBY, filename: filename)
+      describe Some::Class, '.inst' do; end
+    RUBY
   end
 
   it 'ignores non-alphanumeric characters' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '#pred?' do; end",
-      'some/class/pred_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class/pred_spec.rb')
+      describe Some::Class, '#pred?' do; end
+    RUBY
   end
 
   it 'allows bang method' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '#bang!' do; end",
-      'some/class/bang_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    expect_no_violations(<<-RUBY, filename: 'some/class/bang_spec.rb')
+      describe Some::Class, '#bang!' do; end
+    RUBY
   end
 
   it 'allows flexibility with predicates' do
-    inspect_source(
-      cop,
-      "describe Some::Class, '#thing?' do; end",
-      'some/class/thing_predicate_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    filename = 'some/class/thing_predicate_spec.rb'
+    expect_no_violations(<<-RUBY, filename: filename)
+      describe Some::Class, '#thing?' do; end
+    RUBY
   end
 
   it 'allows flexibility with operators' do
-    inspect_source(
-      cop,
-      "describe MyLittleClass, '#<=>' do; end",
-      'my_little_class/spaceship_operator_spec.rb'
-    )
-    expect(cop.offenses).to be_empty
+    filename = 'my_little_class/spaceship_operator_spec.rb'
+    expect_no_violations(<<-RUBY, filename: filename)
+      describe MyLittleClass, '#<=>' do; end
+    RUBY
   end
 
   context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
     it 'respects custom module name transformation' do
-      inspect_source(
-        cop,
-        "describe FooFoo::Some::Class, '#bar' do; end",
-        'foofoo/some/class/bar_spec.rb'
-      )
-      expect(cop.offenses).to be_empty
+      expect_no_violations(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
+        describe FooFoo::Some::Class, '#bar' do; end
+      RUBY
     end
 
     it 'ignores routing specs' do
-      inspect_source(
-        cop,
-        'describe MyController, "#foo", type: :routing do; end',
-        'foofoo/some/class/bar_spec.rb'
-      )
-      expect(cop.offenses).to be_empty
+      expect_no_violations(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
+        describe MyController, "#foo", type: :routing do; end
+      RUBY
     end
   end
 
@@ -244,12 +184,9 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 
     it 'does not care about the described method' do
-      inspect_source(
-        cop,
-        "describe MyClass, '#look_here_a_method' do; end",
-        'my_class_spec.rb'
-      )
-      expect(cop.offenses).to be_empty
+      expect_no_violations(<<-RUBY, filename: 'my_class_spec.rb')
+        describe MyClass, '#look_here_a_method' do; end
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Converts specs to use `expect_violation` as well as refactors the cop itself in the following ways:

- Use `File.fnmatch?` instead of generating a file matching regex.
- Leverage node mappers instead of manual destructuring.
- Use `#fetch` with defaults instead of `a[b] || c`.
- Reorder methods so they appear in roughly the order they are used.
- Rename various methods and variables to improve readability.