### PR TITLE
Fix message constant access modifier

### DIFF
--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -41,8 +41,6 @@ module RuboCop
         def message(_node)
           format(MSG, style, alternative_style)
         end
-
-        private_constant(*constants(false))
       end
     end
   end


### PR DESCRIPTION
- This interferes with `bin/build_config`. I introduced it earlier, but
  didn't realize it would have any effect on anything else.