### PR TITLE
Flag repeated 'it' in `it` docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Add repeated 'it' detection to `RSpec/ExampleWording` cop. ([@dgollahon][])
 * Add `RSpec/ItBehavesLike` cop. ([@dgollahon][])
 * Add `RSpec/SharedContext` cop. ([@Darhazer][])
 * `Rspec/MultipleExpectations`: Count aggregate_failures block as single expectation. ([@Darhazer][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -53,7 +53,7 @@ RSpec/ExampleLength:
   Max: 5
 
 RSpec/ExampleWording:
-  Description: Checks that example descriptions do not start with "should".
+  Description: Checks for common mistakes in example descriptions.
   Enabled: true
   CustomTransform:
     be: is

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module RSpec
-      # Checks that example descriptions do not start with "should".
+      # Checks for common mistakes in example descriptions.
+      #
+      # This cop will correct docstrings that begin with 'should' and 'it'.
       #
       # @see http://betterspecs.org/#should
       #
@@ -18,8 +20,21 @@ module RuboCop
       #   # good
       #   it 'finds nothing' do
       #   end
+      #
+      # @example
+      #   # bad
+      #   it 'it does things' do
+      #   end
+      #
+      #   # good
+      #   it 'does things' do
+      #   end
       class ExampleWording < Cop
-        MSG = 'Do not use should when describing your tests.'.freeze
+        MSG_SHOULD = 'Do not use should when describing your tests.'.freeze
+        MSG_IT     = "Do not repeat 'it' when describing your tests.".freeze
+
+        SHOULD_PREFIX = 'should'.freeze
+        IT_PREFIX     = 'it '.freeze
 
         def_node_matcher(
           :it_description,
@@ -28,38 +43,49 @@ module RuboCop
 
         def on_block(node)
           it_description(node) do |description_node, message|
-            return unless message.downcase.start_with?('should')
+            text = message.downcase
 
-            add_wording_offense(description_node)
+            if text.start_with?(SHOULD_PREFIX)
+              add_wording_offense(description_node, MSG_SHOULD)
+            elsif text.start_with?(IT_PREFIX)
+              add_wording_offense(description_node, MSG_IT)
+            end
           end
         end
 
         def autocorrect(range)
           lambda do |corrector|
-            corrector.replace(
-              range,
-              RuboCop::RSpec::Wording.new(
-                range.source,
-                ignore:  ignored_words,
-                replace: custom_transform
-              ).rewrite
-            )
+            corrector.replace(range, replacement_text(range))
           end
         end
 
         private
 
-        def add_wording_offense(node)
+        def add_wording_offense(node, message)
           expr = node.loc.expression
 
-          message =
+          docstring =
             Parser::Source::Range.new(
               expr.source_buffer,
               expr.begin_pos + 1,
               expr.end_pos - 1
             )
 
-          add_offense(message, message)
+          add_offense(docstring, docstring, message)
+        end
+
+        def replacement_text(range)
+          text = range.source
+
+          if text.start_with?('should')
+            RuboCop::RSpec::Wording.new(
+              text,
+              ignore:  ignored_words,
+              replace: custom_transform
+            ).rewrite
+          elsif text.start_with?(IT_PREFIX)
+            text.sub(IT_PREFIX, '')
+          end
         end
 
         def custom_transform

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -37,6 +37,21 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
       RUBY
     end
 
+    it 'finds leading its' do
+      expect_violation(<<-RUBY)
+        it "it does something" do
+            ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
+        end
+      RUBY
+    end
+
+    it "skips words beginning with 'it'" do
+      expect_no_violations(<<-RUBY)
+        it 'itemizes items' do
+        end
+      RUBY
+    end
+
     it 'skips descriptions without `should` at the beginning' do
       expect_no_violations(<<-RUBY)
         it 'finds no should here' do
@@ -47,6 +62,10 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     include_examples 'autocorrect',
                      'it "should only have trait" do end',
                      'it "only has trait" do end'
+
+    include_examples 'autocorrect',
+                     'it "it does something" do end',
+                     'it "does something" do end'
   end
 
   context 'when configuration is empty' do

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   context 'when inspecting rspec-rails routing specs' do
     let(:cop_config) { {} }
 
-    it 'it ignores rspec-rails routing specs' do
+    it 'ignores rspec-rails routing specs' do
       inspect_source(
         cop,
         'expect(get: "/foo").to be_routeable',

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
   end
 
   context 'shared_examples' do
-    it 'it does not register an offense for empty examples' do
+    it 'does not register an offense for empty examples' do
       expect_no_violations(<<-RUBY)
         shared_examples 'empty' do
         end


### PR DESCRIPTION
- Checks for things like `it 'it does something' do; end'
- Actually fixed a few instances in our own codebase, which is
  satisfying!