### PR TITLE
Consistently add 2 space indentation to HEREDOCs

### DIFF
--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -23,20 +23,20 @@ module RuboCop
               'the class or module being tested.'.freeze
 
         def_node_matcher :valid_describe?, <<-PATTERN
-        {(send {(const nil :RSpec) nil} :describe const ...) (send nil :describe)}
+          {(send {(const nil :RSpec) nil} :describe const ...) (send nil :describe)}
         PATTERN
 
         def_node_matcher :describe_with_metadata, <<-PATTERN
-        (send {(const nil :RSpec) nil} :describe
-          !const
-          ...
-          (hash $...))
+          (send {(const nil :RSpec) nil} :describe
+            !const
+            ...
+            (hash $...))
         PATTERN
 
         def_node_matcher :rails_metadata?, <<-PATTERN
-        (pair
-          (sym :type)
-          (sym {:request :feature :routing :view}))
+          (pair
+            (sym :type)
+            (sym {:request :feature :routing :view}))
         PATTERN
 
         def_node_matcher :shared_group?, <<-PATTERN

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -66,7 +66,7 @@ module RuboCop
         HOOKS = Hooks::ALL.node_pattern_union.freeze
 
         def_node_matcher :scoped_hook, <<-PATTERN
-        (block $(send nil #{HOOKS} (sym ${:each :example})) ...)
+          (block $(send nil #{HOOKS} (sym ${:each :example})) ...)
         PATTERN
 
         def_node_matcher :unscoped_hook, "(block $(send nil #{HOOKS}) ...)"

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -27,19 +27,19 @@ module RuboCop
         def_node_matcher :example?, "(block $(send nil #{EXAMPLES}) ...)"
 
         def_node_search :null_double, <<-PATTERN
-        (lvasgn $_
-          (send
-            $(send nil :instance_double
-              ...) :as_null_object))
+          (lvasgn $_
+            (send
+              $(send nil :instance_double
+                ...) :as_null_object))
         PATTERN
 
         def_node_search :have_received_usage, <<-PATTERN
-        (send
-          (send nil :expect
-          (lvar $_)) :to
-          (send nil :have_received
+          (send
+            (send nil :expect
+            (lvar $_)) :to
+            (send nil :have_received
+            ...)
           ...)
-        ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -51,12 +51,12 @@ module RuboCop
         MSG = 'Example has too many expectations [%{total}/%{max}].'.freeze
 
         def_node_search :example_with_aggregated_failures?, <<-PATTERN
-        (pair (sym :aggregate_failures) (true))
+          (pair (sym :aggregate_failures) (true))
         PATTERN
 
         def_node_matcher :expect?, '(send _ :expect ...)'
         def_node_matcher :aggregate_failures?, <<-PATTERN
-        (block (send _ :aggregate_failures ...) ...)
+          (block (send _ :aggregate_failures ...) ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -39,10 +39,10 @@ module RuboCop
         #
         #   @yield [Symbol] subject name
         def_node_matcher :subject, <<-PATTERN
-        {
-          (block (send nil :subject (sym $_)) args ...)
-          (block (send nil $:subject) args ...)
-        }
+          {
+            (block (send nil :subject (sym $_)) args ...)
+            (block (send nil $:subject) args ...)
+          }
         PATTERN
 
         # @!method message_expectation?(node, method_name)

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -17,7 +17,7 @@ module RuboCop
       #
       #   Detect if node is `before`, `after`, `around`
       def_node_matcher :hook, <<-PATTERN
-      (block {$(send nil #{Hooks::ALL.node_pattern_union} ...)} ...)
+        (block {$(send nil #{Hooks::ALL.node_pattern_union} ...)} ...)
       PATTERN
 
       def examples

--- a/spec/expect_violation/expectation_spec.rb
+++ b/spec/expect_violation/expectation_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe ExpectViolation::Expectation do
   context 'when given a single assertion on class end' do
     let(:string) do
       <<-SRC
-      class Foo
-      end
-      ^^^ The end of `Foo` should be annotated.
+        class Foo
+        end
+        ^^^ The end of `Foo` should be annotated.
       SRC
     end
 
@@ -23,7 +23,7 @@ RSpec.describe ExpectViolation::Expectation do
     end
 
     it 'has an assertion on column range 1-3' do
-      expect(assertion.column_range).to eql(6...9)
+      expect(assertion.column_range).to eql(8...11)
     end
 
     it 'has an assertion with correct violation message' do
@@ -32,8 +32,8 @@ RSpec.describe ExpectViolation::Expectation do
 
     it 'recreates source' do
       expect(expectation.source).to eql(<<-RUBY)
-      class Foo
-      end
+        class Foo
+        end
       RUBY
     end
   end
@@ -41,13 +41,13 @@ RSpec.describe ExpectViolation::Expectation do
   context 'when given many assertions on two lines' do
     let(:string) do
       <<-SRC
-      foo bar
-          ^ Charlie
-         ^^ Charlie
-          ^^ Bronco
-          ^^ Alpha
-      baz
-      ^ Delta
+        foo bar
+            ^ Charlie
+           ^^ Charlie
+            ^^ Bronco
+            ^^ Alpha
+        baz
+        ^ Delta
       SRC
     end
 
@@ -65,7 +65,7 @@ RSpec.describe ExpectViolation::Expectation do
 
     it 'has assertions on column range 1-3' do
       expect(assertions.map(&:column_range)).to eql(
-        [9...11, 10...11, 10...12, 10...12, 6...7]
+        [11...13, 12...13, 12...14, 12...14, 8...9]
       )
     end
 
@@ -77,8 +77,8 @@ RSpec.describe ExpectViolation::Expectation do
 
     it 'recreates source' do
       expect(expectation.source).to eql(<<-RUBY)
-      foo bar
-      baz
+        foo bar
+        baz
       RUBY
     end
   end

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -44,16 +44,16 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
   end
 
   original = <<-RUBY
-  it do
-    foo = instance_double(Foo, :name).as_null_object
-    expect(foo).to have_received(:bar)
-  end
+    it do
+      foo = instance_double(Foo, :name).as_null_object
+      expect(foo).to have_received(:bar)
+    end
   RUBY
   corrected = <<-RUBY
-  it do
-    foo = instance_spy(Foo, :name)
-    expect(foo).to have_received(:bar)
-  end
+    it do
+      foo = instance_spy(Foo, :name)
+      expect(foo).to have_received(:bar)
+    end
   RUBY
 
   include_examples 'autocorrect', original, corrected

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -94,15 +94,15 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
 
     it 'does not register an offense for `shared_examples` with it' do
       expect_no_violations(<<-RUBY)
-      shared_examples 'foo' do
-        subject(:foo) { 'foo' }
-        let(:bar) { :baz }
-        before { initialize }
+        shared_examples 'foo' do
+          subject(:foo) { 'foo' }
+          let(:bar) { :baz }
+          before { initialize }
 
-        it 'works' do
+          it 'works' do
+          end
         end
-      end
-    RUBY
+      RUBY
     end
   end
 

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
     formatter = described_class.new(config, descriptions)
 
     expect(formatter.dump).to eql(<<-YAML.gsub(/^\s+\|/, ''))
-    |---
-    |AllCops:
-    |  Setting: fourty two
-    |
-    |RSpec/Foo:
-    |  Config: 2
-    |  Enabled: true
-    |  Description: Blah
-    |
-    |RSpec/Bar:
-    |  Enabled: true
-    |  Description: Wow
+      |---
+      |AllCops:
+      |  Setting: fourty two
+      |
+      |RSpec/Foo:
+      |  Config: 2
+      |  Enabled: true
+      |  Description: Blah
+      |
+      |RSpec/Bar:
+      |  Enabled: true
+      |  Description: Wow
     YAML
   end
 end

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -5,32 +5,32 @@ require 'rubocop/rspec/description_extractor'
 RSpec.describe RuboCop::RSpec::DescriptionExtractor do
   let(:yardocs) do
     YARD.parse_string(<<-RUBY)
-    # This is not a cop
-    class RuboCop::Cop::Mixin::Sneaky
-    end
-
-    # This is not a concrete cop
-    #
-    # @abstract
-    class RuboCop::Cop::RSpec::Cop
-    end
-
-    # Checks foo
-    #
-    # Some description
-    #
-    # @note only works with foo
-    class RuboCop::Cop::RSpec::Foo
-      # Hello
-      def bar
+      # This is not a cop
+      class RuboCop::Cop::Mixin::Sneaky
       end
-    end
 
-    class RuboCop::Cop::RSpec::Undocumented
-      # Hello
-      def bar
+      # This is not a concrete cop
+      #
+      # @abstract
+      class RuboCop::Cop::RSpec::Cop
       end
-    end
+
+      # Checks foo
+      #
+      # Some description
+      #
+      # @note only works with foo
+      class RuboCop::Cop::RSpec::Foo
+        # Hello
+        def bar
+        end
+      end
+
+      class RuboCop::Cop::RSpec::Undocumented
+        # Hello
+        def bar
+        end
+      end
     RUBY
 
     YARD::Registry.all

--- a/spec/rubocop/rspec/example_group_spec.rb
+++ b/spec/rubocop/rspec/example_group_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe RuboCop::RSpec::ExampleGroup do
 
   let(:source) do
     <<-RUBY
-    RSpec.describe Foo do
-      it 'does x' do
-        x
-      end
+      RSpec.describe Foo do
+        it 'does x' do
+          x
+        end
 
-      it 'does y' do
-        y
-      end
+        it 'does y' do
+          y
+        end
 
-      context 'nested' do
-        it 'does z' do
-          z
+        context 'nested' do
+          it 'does z' do
+            z
+          end
         end
       end
-    end
     RUBY
   end
 


### PR DESCRIPTION
It seems we have an inconsistent choice of style 😱  regarding indentation of HEREDOCs. Because the spacing inside HEREDOCs is *actually* spaces in a string, I don’t think we can check them using, well, Rubocop.

In e.g. Ruby code and AST patterns, spaces don’t matter, so we can add or remove indentation as we like. I prefer 2 extra spaces of indentation, but won’t force anything on anyone. Except for consistency, of course.