### PR TITLE
Accept :aggregate_failures as aggregate_failures: true

### DIFF
--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -50,8 +50,9 @@ module RuboCop
 
         MSG = 'Example has too many expectations [%{total}/%{max}].'.freeze
 
-        def_node_search :example_with_aggregated_failures?, <<-PATTERN
-          (pair (sym :aggregate_failures) (true))
+        def_node_search :with_aggregated_failures?, '(sym :aggregate_failures)'
+        def_node_search :disabled_aggregated_failures?, <<-PATTERN
+          (pair (sym :aggregate_failures) (false))
         PATTERN
 
         def_node_matcher :expect?, '(send _ :expect ...)'
@@ -74,6 +75,13 @@ module RuboCop
         end
 
         private
+
+        def example_with_aggregated_failures?(node)
+          example = node.children.first
+
+          with_aggregated_failures?(example) &&
+            !disabled_aggregated_failures?(example)
+        end
 
         def find_expectation(node, &block)
           return unless node.is_a?(Parser::AST::Node)

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -60,27 +60,40 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
   end
 
-  it 'ignores examples with `aggregate_failures: true` meta data' do
-    expect_no_violations(<<-RUBY)
-      describe Foo do
-        it 'uses expect twice', aggregate_failures: true do
-          expect(foo).to eq(bar)
-          expect(baz).to eq(bar)
+  context 'with meta data' do
+    it 'ignores examples with `:aggregate_failures`' do
+      expect_no_violations(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice', :aggregate_failures do
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
+          end
         end
-      end
-    RUBY
-  end
+      RUBY
+    end
 
-  it 'ignores `aggregate_failures: false` meta data' do
-    expect_violation(<<-RUBY)
-      describe Foo do
-        it 'uses expect twice', aggregate_failures: false do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
-          expect(foo).to eq(bar)
-          expect(baz).to eq(bar)
+    it 'ignores examples with `aggregate_failures: true`' do
+      expect_no_violations(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice', aggregate_failures: true do
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
+
+    it 'checks examples with `aggregate_failures: false`' do
+      expect_violation(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice', aggregate_failures: false do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
+          end
+        end
+      RUBY
+    end
   end
 
   context 'with configuration' do


### PR DESCRIPTION
@backus 
The original fix didn't account that you can specify `it "something", :aggregate_failures` which default to true. The boolean option is actually to overwrite the value when you specify globally that failures have to be aggregated. 