### PR TITLE
Fix error when handling empty describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/DescribeSymbol` cop. ([@tsigo][])
+* Fix error when `RSpec/OverwritingSetup` and `RSpec/ScatteredLet` analyzed empty example groups. ([@backus][])
 
 ## 1.14.0 (2017-03-24)
 

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -29,7 +29,7 @@ module RuboCop
         PATTERN
 
         def on_block(node)
-          return unless example_group?(node)
+          return unless example_group_with_body?(node)
 
           _describe, _args, body = *node
 

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -32,7 +32,7 @@ module RuboCop
         def_node_matcher :let?, '(block (send nil {:let :let!} ...) ...)'
 
         def on_block(node)
-          return unless example_group?(node)
+          return unless example_group_with_body?(node)
 
           _describe, _args, body = *node
 

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -8,6 +8,11 @@ module RuboCop
         extend RuboCop::NodePattern::Macros
 
         def_node_matcher :example_group?, ExampleGroups::ALL.block_pattern
+
+        def_node_matcher :example_group_with_body?, <<-PATTERN
+          (block #{ExampleGroups::ALL.send_pattern} args [!nil])
+        PATTERN
+
         def_node_matcher :example?, Examples::ALL.block_pattern
       end
     end

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -43,4 +43,9 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
       end
     RUBY
   end
+
+  it 'does not encounter an error when handling an empty describe' do
+    expect { inspect_source(cop, 'RSpec.describe(User) do end', 'a_spec.rb') }
+      .not_to raise_error
+  end
 end

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -23,4 +23,9 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
   end
+
+  it 'does not encounter an error when handling an empty describe' do
+    expect { inspect_source(cop, 'RSpec.describe(User) do end', 'a_spec.rb') }
+      .not_to raise_error
+  end
 end


### PR DESCRIPTION
Fixes bbatsov/rubocop#4170 and backus/rubocop-rspec#385


The error encountered came from analyzing this code

    RSpec.describe User, type: :model do
    end

which parses as

    (block
      (send
        (const nil :RSpec) :describe
        (const nil :User)
        (hash
          (pair
            (sym :type)
            (sym :model))))
      (args) nil)

so it passes the `example_group?` node matcher but when we destructure
to get the body we get `nil`. In these cops we then called `each_child_node`
on the `nil` body.
