### PR TITLE
Update array delimiter style

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,4 +44,4 @@ task confirm_config: :build_config do
   end
 end
 
-task default: %i(build_config coverage internal_investigation confirm_config)
+task default: %i[build_config coverage internal_investigation confirm_config]

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -19,7 +19,7 @@ module RuboCop
       class ExpectActual < Cop
         MSG = 'Provide the actual you are testing to `expect(...)`.'.freeze
 
-        SIMPLE_LITERALS = %i(
+        SIMPLE_LITERALS = %i[
           true
           false
           nil
@@ -30,16 +30,16 @@ module RuboCop
           complex
           rational
           regopt
-        ).freeze
+        ].freeze
 
-        COMPLEX_LITERALS = %i(
+        COMPLEX_LITERALS = %i[
           array
           hash
           pair
           irange
           erange
           regexp
-        ).freeze
+        ].freeze
 
         def_node_matcher :expect_literal, '(send _ :expect $#literal?)'
 

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -54,7 +54,7 @@ module RuboCop
         private
 
         def let?(node)
-          %i(let let!).include?(node.method_name)
+          %i[let let!].include?(node.method_name)
         end
 
         def find_first_let(node)

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -29,7 +29,7 @@ module RuboCop
 
         MSG = 'Prefer `%s` for setting message expectations.'.freeze
 
-        SUPPORTED_STYLES = %w(allow expect).freeze
+        SUPPORTED_STYLES = %w[allow expect].freeze
 
         def_node_matcher :message_expectation, <<-PATTERN
           (send $(send nil {:expect :allow} ...) :to #receive_message?)

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -34,7 +34,7 @@ module RuboCop
                             'expectations. Setup `%s` as a spy using `allow`'\
                             ' or `instance_spy`.'.freeze
 
-        SUPPORTED_STYLES = %w(have_received receive).freeze
+        SUPPORTED_STYLES = %w[have_received receive].freeze
 
         def_node_matcher :message_expectation, %(
           (send (send nil :expect $_) {:to :to_not :not_to} ...)

--- a/lib/rubocop/rspec/hook.rb
+++ b/lib/rubocop/rspec/hook.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Wrapper for RSpec hook
     class Hook < Concept
-      STANDARDIZED_SCOPES = %i(each context suite).freeze
+      STANDARDIZED_SCOPES = %i[each context suite].freeze
       private_constant(:STANDARDIZED_SCOPES)
 
       def name

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -44,49 +44,49 @@ module RuboCop
       end
 
       module Matchers
-        MESSAGE_CHAIN = SelectorSet.new(%i(receive_message_chain stub_chain))
+        MESSAGE_CHAIN = SelectorSet.new(%i[receive_message_chain stub_chain])
       end
 
       module ExampleGroups
-        GROUPS  = SelectorSet.new(%i(describe context feature example_group))
-        SKIPPED = SelectorSet.new(%i(xdescribe xcontext xfeature))
-        FOCUSED = SelectorSet.new(%i(fdescribe fcontext ffeature))
+        GROUPS  = SelectorSet.new(%i[describe context feature example_group])
+        SKIPPED = SelectorSet.new(%i[xdescribe xcontext xfeature])
+        FOCUSED = SelectorSet.new(%i[fdescribe fcontext ffeature])
 
         ALL = GROUPS + SKIPPED + FOCUSED
       end
 
       module SharedGroups
-        EXAMPLES = SelectorSet.new(%i(shared_examples shared_examples_for))
-        CONTEXT = SelectorSet.new(%i(shared_context))
+        EXAMPLES = SelectorSet.new(%i[shared_examples shared_examples_for])
+        CONTEXT = SelectorSet.new(%i[shared_context])
 
         ALL = EXAMPLES + CONTEXT
       end
 
       module Includes
         EXAMPLES = SelectorSet.new(
-          %i(
+          %i[
             it_behaves_like
             it_should_behave_like
             include_examples
-          )
+          ]
         )
-        CONTEXT = SelectorSet.new(%i(include_context))
+        CONTEXT = SelectorSet.new(%i[include_context])
 
         ALL = EXAMPLES + CONTEXT
       end
 
       module Examples
-        EXAMPLES = SelectorSet.new(%i(it specify example scenario its))
-        FOCUSED  = SelectorSet.new(%i(fit fspecify fexample fscenario focus))
-        SKIPPED  = SelectorSet.new(%i(xit xspecify xexample xscenario skip))
-        PENDING  = SelectorSet.new(%i(pending))
+        EXAMPLES = SelectorSet.new(%i[it specify example scenario its])
+        FOCUSED  = SelectorSet.new(%i[fit fspecify fexample fscenario focus])
+        SKIPPED  = SelectorSet.new(%i[xit xspecify xexample xscenario skip])
+        PENDING  = SelectorSet.new(%i[pending])
 
         ALL = EXAMPLES + FOCUSED + SKIPPED + PENDING
       end
 
       module Hooks
         ALL = SelectorSet.new(
-          %i(
+          %i[
             prepend_before
             before
             append_before
@@ -94,16 +94,16 @@ module RuboCop
             prepend_after
             after
             append_after
-          )
+          ]
         )
       end
 
       module Helpers
-        ALL = SelectorSet.new(%i(let let!))
+        ALL = SelectorSet.new(%i[let let!])
       end
 
       module Subject
-        ALL = SelectorSet.new(%i(subject subject!))
+        ALL = SelectorSet.new(%i[subject subject!])
       end
 
       ALL =

--- a/lib/rubocop/rspec/wording.rb
+++ b/lib/rubocop/rspec/wording.rb
@@ -31,12 +31,12 @@ module RuboCop
         return replacements.fetch(word) if replacements.key?(word)
 
         # ends with o s x ch sh or ss
-        if %w(o s x ch sh).any?(&word.public_method(:end_with?))
+        if %w[o s x ch sh].any?(&word.public_method(:end_with?))
           return "#{word}es"
         end
 
         # ends with y
-        if word.end_with?('y') && !%w(a u o e).include?(word[-2])
+        if word.end_with?('y') && !%w[a u o e].include?(word[-2])
           return "#{word[0..-2]}ies"
         end
 

--- a/spec/expect_violation/expectation_spec.rb
+++ b/spec/expect_violation/expectation_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ExpectViolation::Expectation do
 
     it 'has an assertion with correct violation message' do
       expect(assertions.map(&:message)).to eql(
-        %w(Charlie Charlie Alpha Bronco Delta)
+        %w[Charlie Charlie Alpha Bronco Delta]
       )
     end
 

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'config/default.yml' do
         "RSpec/#{cop_name}"
       end
 
-    cop_names - %w(RSpec/Cop)
+    cop_names - %w[RSpec/Cop]
   end
 
   let(:config_keys) do
-    cop_names + %w(AllCops)
+    cop_names + %w[AllCops]
   end
 
   def cop_configuration(config_key)

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
           }
         },
         'RSpec/FakeCop' => {
-          'Exclude' => %w(bar_spec.rb)
+          'Exclude' => %w[bar_spec.rb]
         }
       }
 

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
 
   context 'when a custom include method is specified' do
     let(:cop_config) do
-      { 'CustomIncludeMethods' => %w(it_has_special_behavior) }
+      { 'CustomIncludeMethods' => %w[it_has_special_behavior] }
     end
 
     it 'does not flag an otherwise empty example group' do

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     let(:cop_config) do
       {
         'CustomTransform' => { 'have' => 'has', 'not' => 'does not' },
-        'IgnoredWords'    => %w(only really)
+        'IgnoredWords'    => %w[only really]
       }
     end
 

--- a/spec/rubocop/rspec/language/selector_set_spec.rb
+++ b/spec/rubocop/rspec/language/selector_set_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe RuboCop::RSpec::Language::SelectorSet do
-  subject(:selector_set) { described_class.new(%i(foo bar)) }
+  subject(:selector_set) { described_class.new(%i[foo bar]) }
 
   it 'composes sets' do
-    combined = selector_set + described_class.new(%i(baz))
+    combined = selector_set + described_class.new(%i[baz])
 
-    expect(combined).to eq(described_class.new(%i(foo bar baz)))
+    expect(combined).to eq(described_class.new(%i[foo bar baz]))
   end
 
   it 'compares by value' do
-    expect(selector_set).not_to eq(described_class.new(%i(foo bar baz)))
+    expect(selector_set).not_to eq(described_class.new(%i[foo bar baz]))
   end
 
   context '#include?' do

--- a/spec/rubocop/rspec/wording_spec.rb
+++ b/spec/rubocop/rspec/wording_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::RSpec::Wording do
   end
 
   let(:ignores) do
-    %w(only really)
+    %w[only really]
   end
 
   expected_rewrites =


### PR DESCRIPTION
- Fixes rubocop violations that are now occuring due to the new rubocop
  release and the corresponding change in the community style guide.