### PR TITLE
Fix example wording autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Fix the handling of various edge cases in the `RSpec/ExampleWording` cop, including one that would cause autocorrect to crash. ([@dgollahon][])
 * Fix false positive in `RSpec/SingleArgumentMessageChain` cop when the single argument is a hash. ([@Darhazer][])
 
 ## 1.15.0 (2017-05-24)

--- a/config/default.yml
+++ b/config/default.yml
@@ -73,8 +73,9 @@ RSpec/ExampleWording:
   Enabled: true
   CustomTransform:
     be: is
+    BE: IS
     have: has
-    not: does not
+    HAVE: HAS
   IgnoredWords: []
 
 RSpec/ExpectActual:

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
   context 'with configuration' do
     let(:cop_config) do
       {
-        'CustomTransform' => { 'have' => 'has', 'not' => 'does not' },
+        'CustomTransform' => { 'have' => 'has' },
         'IgnoredWords'    => %w[only really]
       }
     end
@@ -37,6 +37,22 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
       RUBY
     end
 
+    it 'flags a lone should' do
+      expect_violation(<<-RUBY)
+        it 'should' do
+            ^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
+    end
+
+    it 'flags a lone should not' do
+      expect_violation(<<-RUBY)
+        it 'should not' do
+            ^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
+    end
+
     it 'finds leading its' do
       expect_violation(<<-RUBY)
         it "it does something" do
@@ -59,13 +75,36 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
       RUBY
     end
 
+    it 'skips descriptions starting with words that begin with `should`' do
+      expect_no_violations(<<-RUBY)
+        it 'shoulders the burden' do
+        end
+      RUBY
+    end
+
     include_examples 'autocorrect',
                      'it "should only have trait" do end',
                      'it "only has trait" do end'
 
     include_examples 'autocorrect',
+                     'it "SHOULDN\'T only have trait" do end',
+                     'it "DOES NOT only have trait" do end'
+
+    include_examples 'autocorrect',
                      'it "it does something" do end',
                      'it "does something" do end'
+
+    include_examples 'autocorrect',
+                     'it "It does something" do end',
+                     'it "does something" do end'
+
+    include_examples 'autocorrect',
+                     'it "should" do end',
+                     'it "" do end'
+
+    include_examples 'autocorrect',
+                     'it "should not" do end',
+                     'it "does not" do end'
   end
 
   context 'when configuration is empty' do

--- a/spec/rubocop/rspec/wording_spec.rb
+++ b/spec/rubocop/rspec/wording_spec.rb
@@ -1,11 +1,6 @@
 RSpec.describe RuboCop::RSpec::Wording do
-  let(:replacements) do
-    { 'have' => 'has', 'not' => 'does not' }
-  end
-
-  let(:ignores) do
-    %w[only really]
-  end
+  let(:replacements) { { 'have' => 'has' } }
+  let(:ignores)      { %w[only really]     }
 
   expected_rewrites =
     {
@@ -26,7 +21,18 @@ RSpec.describe RuboCop::RSpec::Wording do
       'should search the internet'         => 'searches the internet',
       'should wish me luck'                => 'wishes me luck',
       'should really only return one item' => 'really only returns one item',
-      "shouldn't return something"         => 'does not return something'
+      "shouldn't return something"         => 'does not return something',
+      'SHOULD RETAIN UPPERCASE'            => 'RETAINS UPPERCASE',
+      "shouldn't be true"                  => 'is not true',
+      "SHOULDN'T BE true"                  => 'IS NOT true',
+      "SHOULDN'T NOT RETAIN UPPERCASE"     => 'DOES NOT NOT RETAIN UPPERCASE',
+      'should WORRY'                       => 'WORRIES',
+      'should WISH me luck'                => 'WISHES me luck',
+      ''                                   => '',
+      'should'                             => '',
+      "shouldn't"                          => 'does not',
+      'should not'                         => 'does not',
+      'should fizz'                        => 'fizzes'
     }
 
   expected_rewrites.each do |old, new|


### PR DESCRIPTION
Fix example wording autocorrect

- Fixes #402
- Previously the `#on_block` method would correctly flag cases of leading
  `it` and `should` case-insensitively by downcasing the docstring but
  in the autocorrect phase the message casing  was left untouched which
  caused a nil bug for upper cased `Should`s, `IT`s, etc.
- Prevents words starting with `should` from being flagged
  * ex: `it 'shoulders the burden' {}`
- Improves `shouldn't be` handling
  * original docstring: `shouldn't be true`
  * correction before: `does not be true`
  * correction after: `is not true`
- Fixes the pluralizer so that it is not confused by uppercase letters
  * original docstrings: `should WISH ME LUCK`, `should WORRY`
  * corrections before: `WISHs ME LUCK`, `WORRYs`
  * corrections after: `WISHES ME LUCK`, `WORRIES`
- If a whole word being corrected is completely uppercase, the suffix
  appended will also be uppercase. If the word is mixed case, the
  lowercase suffix will be appended.
- Performs general refactoring.
- Adds pluralization support for words ending in `z`
    * ex: `buzz` -> `buzzes`