### PR TITLE
Rename ExpectViolation to ExpectOffense

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -39,8 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'anima'
-  spec.add_development_dependency 'concord'
-  spec.add_development_dependency 'adamantium'
   spec.add_development_dependency 'yard'
 end

--- a/spec/expect_offense/expectation_spec.rb
+++ b/spec/expect_offense/expectation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ExpectViolation::Expectation do
+RSpec.describe ExpectOffense::Expectation do
   subject(:expectation) { described_class.new(string) }
 
   context 'when given a single assertion on class end' do

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   subject(:cop) { described_class.new }
 
   it 'finds `allow_any_instance_of` instead of an instance double' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       before do
         allow_any_instance_of(Object).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `allow_any_instance_of`.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   end
 
   it 'finds `expect_any_instance_of` instead of an instance double' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       before do
         expect_any_instance_of(Object).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `expect_any_instance_of`.
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   end
 
   it 'finds old `any_instance` syntax instead of an instance double' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       before do
         Object.any_instance.should_receive(:foo)
         ^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `any_instance`.

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when no value is yielded' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         around do
         ^^^^^^^^^ Test object should be passed to around block.
           do_something
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when the hook is scoped with a symbol' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         around(:each) do
         ^^^^^^^^^^^^^^^^ Test object should be passed to around block.
           do_something
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when the yielded value is unused' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         around do |test|
                    ^^^^ You should call `test.call` or `test.run`.
           do_something
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when two values are yielded and the first is unused' do
     it 'registers an offense for the first argument' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         around do |test, unused|
                    ^^^^ You should call `test.call` or `test.run`.
           unused.run
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when the yielded value is referenced but not used' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         around do |test|
                    ^^^^ You should call `test.call` or `test.run`.
           test
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when a method other than #run or #call is called' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         around do |test|
                    ^^^^ You should call `test.call` or `test.run`.
           test.inspect
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when #run is called' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         around do |test|
           test.run
         end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when #call is called' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         around do |test|
           test.call
         end
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when used as a block arg' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         around do |test|
           1.times(&test)
         end
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when passed to another method' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         around do |test|
           something_that_might_run_test(test, another_arg)
         end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when yielded to another block' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         around do |test|
           foo { yield(some_arg, test) }
         end

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for `eql` when argument is a boolean' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it { expect(foo).to eql(true) }
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(false) }
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
   end
 
   it 'registers an offense for `eql` when argument is an integer' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it { expect(foo).to eql(0) }
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(123) }
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
   end
 
   it 'registers an offense for `eql` when argument is a float' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it { expect(foo).to eql(1.0) }
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(1.23) }
@@ -29,27 +29,27 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
   end
 
   it 'registers an offense for `eql` when argument is a symbol' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it { expect(foo).to eql(:foo) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is nil' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it { expect(foo).to eql(nil) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
   end
 
   it 'does not register an offense for `eql` when argument is a string' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it { expect(foo).to eql('foo') }
     RUBY
   end
 
   it 'does not register an offense for `eql` when expectation is negated' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it { expect(foo).to_not eql(1) }
     RUBY
   end

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
 
   context 'when using before all' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before(:all) { do_something }
         ^^^^^^^^^^^^ #{message('before(:all)')}
         before(:context) { do_something }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
 
   context 'when using after all' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         after(:all) { do_something }
         ^^^^^^^^^^^ #{message('after(:all)')}
         after(:context) { do_something }
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
 
   context 'when using before each' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before(:each) { do_something }
         before(:example) { do_something }
       RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll, :config do
 
   context 'when using after each' do
     it 'does not register an offense' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         after(:each) { do_something }
         after(:example) { do_something }
       RUBY

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the source path ends with `_spec.rb`' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY, filename: 'foo_spec.rb')
+      expect_offense(<<-RUBY, filename: 'foo_spec.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
     end
 
     it 'ignores the file if it is ignored' do
-      expect_no_violations(<<-RUBY, filename: 'bar_spec.rb')
+      expect_no_offenses(<<-RUBY, filename: 'bar_spec.rb')
         foo(1)
       RUBY
     end
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the source path contains `/spec/`' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY, filename: '/spec/support/thing.rb')
+      expect_offense(<<-RUBY, filename: '/spec/support/thing.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the source path starts with `spec/`' do
     it 'registers an offense' do
-      expect_violation(<<-RUBY, filename: 'spec/support/thing.rb')
+      expect_offense(<<-RUBY, filename: 'spec/support/thing.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
@@ -71,13 +71,13 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the file is a source file without "spec" in the name' do
     it 'ignores the source when the path is not a spec file' do
-      expect_no_violations(<<-RUBY, filename: 'foo.rb')
+      expect_no_offenses(<<-RUBY, filename: 'foo.rb')
         foo(1)
       RUBY
     end
 
     it 'ignores the source when the path is not a specified pattern' do
-      expect_no_violations(<<-RUBY, filename: 'foo_test.rb')
+      expect_no_offenses(<<-RUBY, filename: 'foo_test.rb')
         foo(1)
       RUBY
     end
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
     end
 
     it 'registers offenses when the path matches a custom specified pattern' do
-      expect_violation(<<-RUBY, filename: 'foo_test.rb')
+      expect_offense(<<-RUBY, filename: 'foo_test.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   subject(:cop) { described_class.new }
 
   it 'checks first-line describe statements' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe "bad describe" do
                ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -10,14 +10,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'supports RSpec.describe' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe Foo do
       end
     RUBY
   end
 
   it 'checks describe statements after a require' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       require 'spec_helper'
       describe "bad describe" do
                ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'checks highlights the first argument of a describe' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe "bad describe", "blah blah" do
                ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores nested describe statements' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Some::Class do
         describe "bad describe" do
         end
@@ -43,28 +43,28 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores request specs' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'my new feature', type: :request do
       end
     RUBY
   end
 
   it 'ignores feature specs' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'my new feature', type: :feature do
       end
     RUBY
   end
 
   it 'ignores feature specs when RSpec.describe is used' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe 'my new feature', type: :feature do
       end
     RUBY
   end
 
   it 'flags specs with non :type metadata' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe 'my new feature', foo: :feature do
                ^^^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'flags normal metadata in describe' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe 'my new feature', blah, type: :wow do
                ^^^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -80,39 +80,39 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores feature specs - also with complex options' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'my new feature', :test, :type => :feature, :foo => :bar do
       end
     RUBY
   end
 
   it 'ignores an empty describe' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe do
       end
     RUBY
   end
 
   it 'ignores routing specs' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'my new route', type: :routing do
       end
     RUBY
   end
 
   it 'ignores view specs' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'widgets/index', type: :view do
       end
     RUBY
   end
 
   it "doesn't blow up on single-line describes" do
-    expect_no_violations('describe Some::Class')
+    expect_no_offenses('describe Some::Class')
   end
 
   it "doesn't flag top level describe in a shared example" do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       shared_examples 'Common::Interface' do
         describe '#public_interface' do
           it 'conforms to interface' do
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it "doesn't flag top level describe in a shared context" do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.shared_context 'Common::Interface' do
         describe '#public_interface' do
           it 'conforms to interface' do
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it "doesn't flag top level describe in an unnamed shared context" do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       shared_context do
         describe '#public_interface' do
           it 'conforms to interface' do

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   subject(:cop) { described_class.new }
 
   it 'ignores describes with only a class' do
-    expect_no_violations('describe Some::Class do; end')
+    expect_no_offenses('describe Some::Class do; end')
   end
 
   it 'enforces non-method names' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Some::Class, 'nope', '.incorrect_usage' do
                             ^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'.
       end
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips methods starting with a . or #' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Some::Class, '.asdf' do
       end
 
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips specs not having a string second argument' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Some::Class, :config do
       end
     RUBY

--- a/spec/rubocop/cop/rspec/describe_symbol_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_symbol_spec.rb
@@ -2,28 +2,28 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeSymbol do
   subject(:cop) { described_class.new }
 
   it 'flags violations for `describe :symbol`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe(:some_method) { }
                ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
   it 'flags violations for `describe :symbol` with multiple arguments' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe(:some_method, "description") { }
                ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
   it 'flags violations for `RSpec.describe :symbol`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe(:some_method, "description") { }
                      ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
   it 'flags violations for a nested `describe`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe Foo do
         describe :to_s do
                  ^^^^^ Avoid describing symbols.
@@ -33,10 +33,10 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeSymbol do
   end
 
   it 'does not flag non-Symbol arguments' do
-    expect_no_violations('describe("#some_method") { }')
+    expect_no_offenses('describe("#some_method") { }')
   end
 
   it 'does not flag `context :symbol`' do
-    expect_no_violations('context(:some_method) { }')
+    expect_no_offenses('context(:some_method) { }')
   end
 end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
 
   shared_examples 'SkipBlocks enabled' do
     it 'does not flag violations within non-rspec blocks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           controller(ApplicationController) do
             bar = MyClass
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
 
   shared_examples 'SkipBlocks disabled' do
     it 'flags violations within all blocks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           controller(ApplicationController) do
             bar = MyClass
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     let(:enforced_style) { :described_class }
 
     it 'checks for the use of the described class' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           include MyClass
                   ^^^^^^^ Use `described_class` instead of `MyClass`.
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores described class as string' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyClass do
           subject { "MyClass" }
         end
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores describe that do not reference to a class' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe "MyClass" do
           subject { "MyClass" }
         end
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores class if the scope is changing' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyClass do
           Class.new  { foo = MyClass }
           Module.new { bar = MyClass }
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'only takes class from top level describes' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           describe MyClass::Foo do
             subject { MyClass::Foo }
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores subclasses' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyClass do
           subject { MyClass::SubClass }
         end
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores if namespace is not matching' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           subject { ::MyClass }
           let(:foo) { MyClass }
@@ -159,7 +159,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'checks for the use of described class with namespace' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyNamespace::MyClass do
           subject { MyNamespace::MyClass }
                     ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`.
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'does not flag violations within a class scope change' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           before do
             class Foo
@@ -180,7 +180,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'does not flag violations within a hook scope change' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe do
           before do
             MyNamespace::MyClass.new
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     it 'checks for the use of described class with module' do
       skip
 
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         module MyNamespace
           describe MyClass do
             subject { MyNamespace::MyClass }
@@ -219,7 +219,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     let(:enforced_style) { :explicit }
 
     it 'checks for the use of the described_class' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           include described_class
                   ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`.
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores described_class as string' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyClass do
           subject { "described_class" }
         end
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'ignores describe that do not reference to a class' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe "MyClass" do
           subject { described_class }
         end
@@ -250,7 +250,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'does not flag violations within a class scope change' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           before do
             class Foo
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'does not flag violations within a hook scope change' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe do
           before do
             described_class.new

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'flags an empty context' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         context 'when bar' do
         ^^^^^^^^^^^^^^^^^^ Empty example group detected.
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   end
 
   it 'flags an empty top level describe' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
       ^^^^^^^^^^^^ Empty example group detected.
       end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   end
 
   it 'does not flag include_examples' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         context "when something is true" do
           include_examples "some expectations"
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   end
 
   it 'does not recognize custom include methods by default' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
       ^^^^^^^^^^^^ Empty example group detected.
         context "when I do something clever" do
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     end
 
     it 'does not flag an otherwise empty example group' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe Foo do
           context "when I do something clever" do
             it_has_special_behavior

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   subject(:cop) { described_class.new }
 
   it 'checks for empty line after last let' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'check for empty line after the last `let!`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let!(:b) do
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'approves empty line after let' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
     RSpec.describe User do
       let(:a) { a }
       let(:b) { b }
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'ignores empty lines between the lets' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
 
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'handles let in tests' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
         # want to avoid false positives
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'handles multiline let block' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) do
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'handles let being the latest node' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'handles HEREDOC for let' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:foo) do
           <<-BAR
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'handles silly HEREDOC syntax for let' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe 'silly heredoc syntax' do
         let(:foo) { <<-BAR }
         hello

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   subject(:cop) { described_class.new }
 
   it 'checks for empty line after subject' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after `subject`.
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'approves empty line after subject' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'handles subjects in tests' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
         # want to avoid false positives
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'handles multiline subject block' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject do
           described_class.new
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'handles let being the latest node' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject { described_user }
       end

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
   let(:cop_config) { { 'Max' => 3 } }
 
   it 'ignores non-spec blocks' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       foo do
         line 1
         line 2
@@ -15,14 +15,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
   end
 
   it 'allows an empty example' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it do
       end
     RUBY
   end
 
   it 'allows a short example' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it do
         line 1
         line 2
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
   end
 
   it 'ignores comments' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it do
         line 1
         line 2
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
 
   context 'when inspecting large examples' do
     it 'flags the example' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
         ^^^^^ Example has too many lines [4/3].
           line 1
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
     end
 
     it 'flags the example' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
         ^^^^^ Example has too many lines [4/3].
           line 1

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'ignores non-example blocks' do
-      expect_no_violations('foo "should do something" do; end')
+      expect_no_offenses('foo "should do something" do; end')
     end
 
     it 'finds description with `should` at the beginning' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it 'should do something' do
             ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
         end
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'finds description with `Should` at the beginning' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it 'Should do something' do
             ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
         end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'finds description with `shouldn\'t` at the beginning' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it "shouldn't do something" do
             ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
         end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'flags a lone should' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it 'should' do
             ^^^^^^ Do not use should when describing your tests.
         end
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'flags a lone should not' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it 'should not' do
             ^^^^^^^^^^ Do not use should when describing your tests.
         end
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it 'finds leading its' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it "it does something" do
             ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
         end
@@ -62,21 +62,21 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     end
 
     it "skips words beginning with 'it'" do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it 'itemizes items' do
         end
       RUBY
     end
 
     it 'skips descriptions without `should` at the beginning' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it 'finds no should here' do
         end
       RUBY
     end
 
     it 'skips descriptions starting with words that begin with `should`' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it 'shoulders the burden' do
         end
       RUBY

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'flags numeric literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(123).to eq(bar)
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags boolean literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(true).to eq(bar)
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags string and symbol literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect("foo").to eq(bar)
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags literal nil value within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(nil).to eq(bar)
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'does not flag dynamic values within expect(...)' do
-    expect_no_violations(<<-'RUBY')
+    expect_no_offenses(<<-'RUBY')
       describe Foo do
         it 'uses expect correctly' do
           expect(foo).to eq(bar)
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags arrays containing only literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect([123]).to eq(bar)
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags hashes containing only literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(foo: 1, bar: 2).to eq(bar)
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags ranges containing only literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1..2).to eq(bar)
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'flags regexps containing only literal values within expect(...)' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(/foo|bar/).to eq(bar)
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
   end
 
   it 'does not flag complex values with dynamic parts within expect(...)' do
-    expect_no_violations(<<-'RUBY')
+    expect_no_offenses(<<-'RUBY')
       describe Foo do
         it 'uses expect incorrectly' do
           expect.to eq(bar)

--- a/spec/rubocop/cop/rspec/expect_output_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_output_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for overwriting $stdout within an example' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       specify do
         $stdout = StringIO.new
         ^^^^^^^ Use `expect { ... }.to output(...).to_stdout` instead of mutating $stdout.
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
 
   it 'registers an offense for overwriting $stderr ' \
      'within an example scoped hook' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       before(:each) do
         $stderr = StringIO.new
         ^^^^^^^ Use `expect { ... }.to output(...).to_stderr` instead of mutating $stderr.
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not register an offense for interacting with $stdout' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       specify do
         $stdout.puts("hi")
       end
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assignments to other global variables' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       specify do
         $blah = StringIO.new
       end
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assignments to $stdout outside of example scope' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       before(:suite) do
         $stderr = StringIO.new
       end
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assignments to $stdout in example_group scope' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         $stderr = StringIO.new
       end
@@ -57,6 +57,6 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assigns to $stdout when in the root scope' do
-    expect_no_violations('$stderr = StringIO.new')
+    expect_no_offenses('$stderr = StringIO.new')
   end
 end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -2,170 +2,170 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for a bad path' do
-    expect_violation(<<-RUBY, filename: 'wrong_path_foo_spec.rb')
+    expect_offense(<<-RUBY, filename: 'wrong_path_foo_spec.rb')
       describe MyClass, 'foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class but a correct method' do
-    expect_violation(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
+    expect_offense(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a repeated .rb' do
-    expect_violation(<<-RUBY, filename: 'my_class/foo_spec.rb.rb')
+    expect_offense(<<-RUBY, filename: 'my_class/foo_spec.rb.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file missing a .rb' do
-    expect_violation(<<-RUBY, filename: 'my_class/foo_specorb')
+    expect_offense(<<-RUBY, filename: 'my_class/foo_specorb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class and highlights metadata' do
-    expect_violation(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
+    expect_offense(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo', blah: :blah do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class name' do
-    expect_violation(<<-RUBY, filename: 'wrong_class_spec.rb')
+    expect_offense(<<-RUBY, filename: 'wrong_class_spec.rb')
       describe MyClass do; end
       ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class name with a symbol argument' do
-    expect_violation(<<-RUBY, filename: 'wrong_class_spec.rb')
+    expect_offense(<<-RUBY, filename: 'wrong_class_spec.rb')
       describe MyClass, :foo do; end
       ^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file missing _spec' do
-    expect_violation(<<-RUBY, filename: 'user.rb')
+    expect_offense(<<-RUBY, filename: 'user.rb')
       describe User do; end
       ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
     RUBY
   end
 
   it 'skips specs that do not describe a class / method' do
-    expect_no_violations(<<-RUBY, filename: 'some/class/spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class/spec.rb')
       describe 'Test something' do; end
     RUBY
   end
 
   it 'skips specs that do have multiple top level describes' do
-    expect_no_violations(<<-RUBY, filename: 'some/class/spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class/spec.rb')
       describe MyClass, 'do_this' do; end
       describe MyClass, 'do_that' do; end
     RUBY
   end
 
   it 'checks class specs' do
-    expect_no_violations(<<-RUBY, filename: 'some/class_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'allows different parent directories' do
-    expect_no_violations(<<-RUBY, filename: 'parent_dir/some/class_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'parent_dir/some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'handles CamelCaps class names' do
-    expect_no_violations(<<-RUBY, filename: 'my_class_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'my_class_spec.rb')
       describe MyClass do; end
     RUBY
   end
 
   it 'handles ACRONYMClassNames' do
-    expect_no_violations(<<-RUBY, filename: 'abc_one/two_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'abc_one/two_spec.rb')
       describe ABCOne::Two do; end
     RUBY
   end
 
   it 'handles ALLCAPS class names' do
-    expect_no_violations(<<-RUBY, filename: 'allcaps_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'allcaps_spec.rb')
       describe ALLCAPS do; end
     RUBY
   end
 
   it 'handles alphanumeric class names' do
-    expect_no_violations(<<-RUBY, filename: 'ipv4_and_ipv6_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'ipv4_and_ipv6_spec.rb')
       describe IPV4AndIPV6 do; end
     RUBY
   end
 
   it 'checks instance methods' do
-    expect_no_violations(<<-RUBY, filename: 'some/class/inst_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'checks class methods' do
-    expect_no_violations(<<-RUBY, filename: 'some/class/inst_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class/inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'allows flat hierarchies for instance methods' do
-    expect_no_violations(<<-RUBY, filename: 'some/class_inst_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class_inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'allows flat hierarchies for class methods' do
-    expect_no_violations(<<-RUBY, filename: 'some/class_inst_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class_inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'allows subdirs for instance methods' do
     filename = 'some/class/instance_methods/inst_spec.rb'
-    expect_no_violations(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename: filename)
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'allows subdirs for class methods' do
     filename = 'some/class/class_methods/inst_spec.rb'
-    expect_no_violations(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename: filename)
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'ignores non-alphanumeric characters' do
-    expect_no_violations(<<-RUBY, filename: 'some/class/pred_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class/pred_spec.rb')
       describe Some::Class, '#pred?' do; end
     RUBY
   end
 
   it 'allows bang method' do
-    expect_no_violations(<<-RUBY, filename: 'some/class/bang_spec.rb')
+    expect_no_offenses(<<-RUBY, filename: 'some/class/bang_spec.rb')
       describe Some::Class, '#bang!' do; end
     RUBY
   end
 
   it 'allows flexibility with predicates' do
     filename = 'some/class/thing_predicate_spec.rb'
-    expect_no_violations(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename: filename)
       describe Some::Class, '#thing?' do; end
     RUBY
   end
 
   it 'allows flexibility with operators' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
-    expect_no_violations(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename: filename)
       describe MyLittleClass, '#<=>' do; end
     RUBY
   end
@@ -174,13 +174,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
     it 'respects custom module name transformation' do
-      expect_no_violations(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
         describe FooFoo::Some::Class, '#bar' do; end
       RUBY
     end
 
     it 'ignores routing specs' do
-      expect_no_violations(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
         describe MyController, "#foo", type: :routing do; end
       RUBY
     end
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 
     it 'does not care about the described method' do
-      expect_no_violations(<<-RUBY, filename: 'my_class_spec.rb')
+      expect_no_offenses(<<-RUBY, filename: 'my_class_spec.rb')
         describe MyClass, '#look_here_a_method' do; end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
 
   # rubocop:disable RSpec/ExampleLength
   it 'flags all rspec example blocks with that include `focus: true`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       example 'test', meta: true, focus: true do; end
                                   ^^^^^^^^^^^ Focused spec found.
       xit 'test', meta: true, focus: true do; end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'flags all rspec example blocks that include `:focus`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       example_group 'test', :focus do; end
                             ^^^^^^ Focused spec found.
       feature 'test', :focus do; end
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'does not flag unfocused specs' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       xcontext      'test' do; end
       xscenario     'test' do; end
       xspecify      'test' do; end
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'does not flag a method that is focused twice' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       fit "foo", :focus do
       ^^^^^^^^^^^^^^^^^ Focused spec found.
       end
@@ -101,14 +101,14 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'ignores non-rspec code with :focus blocks' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       some_method "foo", focus: true do
       end
     RUBY
   end
 
   it 'flags focused block types' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       fdescribe 'test' do; end
       ^^^^^^^^^^^^^^^^ Focused spec found.
       ffeature 'test' do; end

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
 
   shared_examples 'ignored hooks' do
     it 'ignores :context and :suite' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before(:suite) { true }
         after(:suite) { true }
         before(:context) { true }
@@ -18,13 +18,13 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'ignores hooks with more than one argument' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before(:each, :something_custom) { true }
       RUBY
     end
 
     it 'ignores non-rspec hooks' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         setup(:each) { true }
       RUBY
     end
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     let(:enforced_style) { :implicit }
 
     it 'detects :each for hooks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before(:each) { true }
         ^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
         after(:each)  { true }
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'detects :example for hooks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before(:example) { true }
         ^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
         after(:example)  { true }
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'does not flag hooks without default scopes' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before { true }
         after { true }
         before { true }
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     let(:enforced_style) { :each }
 
     it 'detects :each for hooks' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before(:each) { true }
         after(:each)  { true }
         around(:each) { true }
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'detects :example for hooks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before(:example) { true }
         ^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
         after(:example)  { true }
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'does not flag hooks without default scopes' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before { true }
         ^^^^^^ Use `:each` for RSpec hooks.
         after { true }
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     let(:enforced_style) { :example }
 
     it 'detects :example for hooks' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before(:example) { true }
         after(:example)  { true }
         around(:example) { true }
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'detects :each for hooks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before(:each) { true }
         ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
         after(:each)  { true }
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     end
 
     it 'does not flag hooks without default scopes' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before { true }
         ^^^^^^ Use `:example` for RSpec hooks.
         after { true }

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -9,29 +9,29 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
     end
 
     it 'flags it { should }' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { should be_truthy }
              ^^^^^^ Prefer `is_expected.to` over `should`.
       RUBY
     end
 
     it 'flags it { should_not }' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { should_not be_truthy }
              ^^^^^^^^^^ Prefer `is_expected.to_not` over `should_not`.
       RUBY
     end
 
     it 'approves of is_expected.to' do
-      expect_no_violations('it { is_expected.to be_truthy }')
+      expect_no_offenses('it { is_expected.to be_truthy }')
     end
 
     it 'approves of is_expected.to_not' do
-      expect_no_violations('it { is_expected.to_not be_truthy }')
+      expect_no_offenses('it { is_expected.to_not be_truthy }')
     end
 
     it 'approves of is_expected.not_to' do
-      expect_no_violations('it { is_expected.not_to be_truthy }')
+      expect_no_offenses('it { is_expected.not_to be_truthy }')
     end
 
     include_examples 'detects style', 'it { should be_truthy }', 'should'
@@ -50,32 +50,32 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
     end
 
     it 'flags it { is_expected.to }' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { is_expected.to be_truthy }
              ^^^^^^^^^^^^^^ Prefer `should` over `is_expected.to`.
       RUBY
     end
 
     it 'flags it { is_expected.to_not }' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { is_expected.to_not be_truthy }
              ^^^^^^^^^^^^^^^^^^ Prefer `should_not` over `is_expected.to_not`.
       RUBY
     end
 
     it 'flags it { is_expected.not_to }' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { is_expected.not_to be_truthy }
              ^^^^^^^^^^^^^^^^^^ Prefer `should_not` over `is_expected.not_to`.
       RUBY
     end
 
     it 'approves of should' do
-      expect_no_violations('it { should be_truthy }')
+      expect_no_offenses('it { should be_truthy }')
     end
 
     it 'approves of should_not' do
-      expect_no_violations('it { should_not be_truthy }')
+      expect_no_offenses('it { should_not be_truthy }')
     end
 
     include_examples 'detects style',

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
 
   context 'when used with `have_received`' do
     it 'adds an offense for an instance_double with single argument' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
           foo = instance_double(Foo).as_null_object
                 ^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
     end
 
     it 'adds an offense for an instance_double with multiple arguments' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
           foo = instance_double(Foo, :name).as_null_object
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
     end
 
     it 'ignores instance_double when it is not used with as_null_object' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it do
           foo = instance_double(Foo)
           expect(bar).to have_received(:bar)
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
 
   context 'when not used with `have_received`' do
     it 'does not add an offence' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it do
           foo = instance_double(Foo).as_null_object
           expect(bar).to have_received(:bar)

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   subject(:cop) { described_class.new }
 
   it 'finds an instance variable inside a describe' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe MyClass do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'ignores non-spec blocks' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       not_rspec do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'finds an instance variable inside a shared example' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       shared_examples 'shared example' do
         it { expect(@foo).to be_empty }
                     ^^^^ Use `let` instead of an instance variable.
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'ignores an instance variable without describe' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       @foo = []
       @foo.empty?
     RUBY
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
 
   # Regression test for nevir/rubocop-rspec#115
   it 'ignores instance variables outside of specs' do
-    expect_no_violations(<<-RUBY, filename: 'lib/source_code.rb')
+    expect_no_offenses(<<-RUBY, filename: 'lib/source_code.rb')
       feature do
         @foo = bar
 
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     end
 
     it 'flags an instance variable when it is also assigned' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           before { @foo = [] }
           it { expect(@foo).to be_empty }
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     end
 
     it 'ignores an instance variable when it is not assigned' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe MyClass do
           it { expect(@foo).to be_empty }
         end

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
     let(:enforced_style) { :it_behaves_like }
 
     it 'flags a violation for it_should_behave_like' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it_should_behave_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_behaves_like` over `it_should_behave_like` when including examples in a nested context.
       RUBY
     end
 
     it 'does not flag a violation for it_behaves_like' do
-      expect_no_violations("it_behaves_like 'a foo'")
+      expect_no_offenses("it_behaves_like 'a foo'")
     end
 
     include_examples(
@@ -32,14 +32,14 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
     let(:enforced_style) { :it_should_behave_like }
 
     it 'flags a violation for it_behaves_like' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it_behaves_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_should_behave_like` over `it_behaves_like` when including examples in a nested context.
       RUBY
     end
 
     it 'does not flag a violation for it_behaves_like' do
-      expect_no_violations("it_should_behave_like 'a foo'")
+      expect_no_offenses("it_should_behave_like 'a foo'")
     end
 
     include_examples(

--- a/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   subject(:cop) { described_class.new }
 
   it 'flags `each` with an expectation' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| expect(user).to be_valid }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'flags `each` when expectation calls method with arguments' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| expect(user).to be_a(User) }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` without expectation' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| allow(user).to receive(:method) }
       end
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'flags `each` with multiple expectations' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each do |user|
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignore `each` when the body does not contain only expectations' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each do |user|
           allow(Something).to receive(:method).and_return(user)
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` with expectation on property' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| expect(user.name).to be }
       end
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores assignments in the iteration' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| array = array.concat(user) }
       end
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` when there is a negative expectation' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it 'validates users' do
         [user1, user2, user3].each do |user|
           expect(user).not_to receive(:method)

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   subject(:cop) { described_class.new }
 
   it 'checks subject below let' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:params) { foo }
 
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'checks subject below let!' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let!(:params) { foo }
 
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'approves of subject above let' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         context 'blah' do
         end
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'handles subjects in contexts' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:params) { foo }
 
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'handles subjects in tests' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
         # want to avoid false positives

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   subject(:cop) { described_class.new }
 
   it 'complains when let! is used and not referenced' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         let!(:foo) { bar }
         ^^^^^^^^^^ Do not use `let!` for test setup.
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'ignores let! when used in `before`' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         let!(:foo) { bar }
 
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'ignores let! when used in example' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         let!(:foo) { bar }
 
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'complains when let! is used and not referenced within nested group' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         context 'when something special happens' do
           let!(:foo) { bar }

--- a/spec/rubocop/cop/rspec/message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/message_chain_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageChain do
   subject(:cop) { described_class.new }
 
   it 'finds `receive_message_chain`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       before do
         allow(foo).to receive_message_chain(:one, :two) { :three }
                       ^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `receive_message_chain`.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageChain do
   end
 
   it 'finds old `stub_chain` syntax' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       before do
         foo.stub_chain(:one, :two).and_return(:three)
             ^^^^^^^^^^ Avoid stubbing using `stub_chain`.

--- a/spec/rubocop/cop/rspec/message_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/message_expectation_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe RuboCop::Cop::RSpec::MessageExpectation, :config do
     end
 
     it 'flags expect(...).to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to receive(:bar)
         ^^^^^^ Prefer `allow` for setting message expectations.
       RUBY
     end
 
     it 'approves of allow(...).to receive' do
-      expect_no_violations('allow(foo).to receive(:bar)')
+      expect_no_offenses('allow(foo).to receive(:bar)')
     end
 
     include_examples 'detects style', 'allow(foo).to receive(:bar)',  'allow'
@@ -29,14 +29,14 @@ RSpec.describe RuboCop::Cop::RSpec::MessageExpectation, :config do
     end
 
     it 'flags allow(...).to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         allow(foo).to receive(:bar)
         ^^^^^ Prefer `expect` for setting message expectations.
       RUBY
     end
 
     it 'approves of expect(...).to receive' do
-      expect_no_violations('expect(foo).to receive(:bar)')
+      expect_no_offenses('expect(foo).to receive(:bar)')
     end
 
     include_examples 'detects style', 'expect(foo).to receive(:bar)', 'expect'

--- a/spec/rubocop/cop/rspec/message_spies_spec.rb
+++ b/spec/rubocop/cop/rspec/message_spies_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
     end
 
     it 'flags expect(send).to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(lvar).to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         foo = baz
         expect(foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
@@ -24,49 +24,49 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
     end
 
     it 'flags expect(ivar).to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(@foo).to receive(:bar)
                         ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `@foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(const).to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(Foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `Foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).not_to receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).not_to receive(:bar)
                            ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).to_not receive' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to_not receive(:bar)
                            ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).to receive with' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to receive(:bar).with(:baz)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).to receive at_most' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to receive(:bar).at_most(42).times
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'approves of expect(...).to have_received' do
-      expect_no_violations('expect(foo).to have_received(:bar)')
+      expect_no_offenses('expect(foo).to have_received(:bar)')
     end
 
     include_examples 'detects style', 'expect(foo).to receive(:bar)', 'receive'
@@ -82,14 +82,14 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
     end
 
     it 'flags expect(send).to have_received' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(lvar).to have_received' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         foo = baz
         expect(foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
@@ -97,49 +97,49 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
     end
 
     it 'flags expect(ivar).to have_received' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(@foo).to have_received(:bar)
                         ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(const).to have_received' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(Foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).not_to have_received' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).not_to have_received(:bar)
                            ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).to_not have_received' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to_not have_received(:bar)
                            ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).to have_received with' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to have_received(:bar).with(:baz)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).to have_received at_most' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         expect(foo).to have_received(:bar).at_most(42).times
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'approves of expect(...).to receive' do
-      expect_no_violations('expect(foo).to receive(:bar)')
+      expect_no_offenses('expect(foo).to receive(:bar)')
     end
 
     include_examples 'detects style', 'expect(foo).to receive(:bar)', 'receive'

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   subject(:cop) { described_class.new }
 
   it 'finds multiple top level describes with class and method' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe MyClass, '.do_something' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top level describes - try to nest them.
       describe MyClass, '.do_something_else' do; end
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'finds multiple top level describes only with class' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe MyClass do; end
       ^^^^^^^^^^^^^^^^ Do not use multiple top level describes - try to nest them.
       describe MyOtherClass do; end
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'skips single top level describe' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       require 'spec_helper'
 
       describe MyClass do

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     let(:cop_config) { {} }
 
     it 'flags multiple expectations' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe Foo do
           it 'uses expect twice' do
           ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'approves of one expectation per example' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe Foo do
           it 'does something neat' do
             expect(neat).to be(true)
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'counts aggregate_failures as one expectation' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe Foo do
           it 'aggregates failures' do
             aggregate_failures do
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'counts every aggregate_failures as an expectation' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe Foo do
           it 'has multiple aggregate_failures calls' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
 
   context 'with meta data' do
     it 'ignores examples with `:aggregate_failures`' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe Foo do
           it 'uses expect twice', :aggregate_failures do
             expect(foo).to eq(bar)
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'ignores examples with `aggregate_failures: true`' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe Foo do
           it 'uses expect twice', aggregate_failures: true do
             expect(foo).to eq(bar)
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'checks examples with `aggregate_failures: false`' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe Foo do
           it 'uses expect twice', aggregate_failures: false do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'permits two expectations' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         describe Foo do
           it 'uses expect twice' do
             expect(foo).to eq(bar)
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
 
     it 'flags three expectations' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe Foo do
           it 'uses expect three times' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2].

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
   subject(:cop) { described_class.new }
 
   it 'checks `it` and `specify` for explicit subject usage' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
   end
 
   it 'checks before and after for explicit subject usage' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
   end
 
   it 'checks around(:each) for explicit subject usage' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
   end
 
   it 'ignores subject when not wrapped inside a test' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       def foo
         it(subject)
       end

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'flags nested contexts' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe MyClass do
         context 'when foo' do
           context 'when bar' do
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
   end
 
   it 'ignores non-spec context methods' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       class MyThingy
         context 'this is not rspec' do
           context 'but it uses contexts' do
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
     let(:cop_config) { { 'Max' => '2' } }
 
     it 'flags two levels of nesting' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         describe MyClass do
           context 'when foo' do
             context 'when bar' do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'not_to' } }
 
     it 'detects the `to_not` offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { expect(false).to_not be_true }
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
     end
 
     it 'detects no offense when using `not_to`' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it { expect(false).not_to be_true }
       RUBY
     end
@@ -26,14 +26,14 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'to_not' } }
 
     it 'detects the `not_to` offense' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it { expect(false).not_to be_true }
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
     end
 
     it 'detects no offense when using `to_not`' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it { expect(false).to_not be_true }
       RUBY
     end

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   subject(:cop) { described_class.new }
 
   it 'finds overwriten `let`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:a) { b }
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'finds overwriten `subject`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         subject(:a) { a }
 
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'finds `let!` overwriting `let`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { b }
         let!(:a) { b }
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'ignores overwriting in different context' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
 

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for repeated descriptions' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe 'doing x' do
         it "does x" do
         ^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers offense for repeated descriptions separated by a context' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe 'doing x' do
         it "does x" do
         ^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'ignores descriptions repeated in a shared context' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it "does x" do
         end
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'ignores repeated descriptions in a nested context' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it "does x" do
         end
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag tests which do not contain description strings' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it { foo }
         it { bar }

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for repeated example' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe 'doing x' do
         it "does x" do
         ^^^^^^^^^^^^^^ Don't repeat examples within an example group.
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not register a violation if rspec tag magic is involved' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it "does x" do
           expect(foo).to be(bar)
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag examples with different implementations' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it "does x" do
           expect(foo).to have_attribute(foo: 1)
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag examples when different its arguments are used' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         its(:y) { is_expected.to be_present }
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag repeated examples in different scopes' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it "does x" do
           expect(foo).to be(bar)

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   subject(:cop) { described_class.new }
 
   it 'flags `let` after the first different node ' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         subject { User }
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'doesnt flag `let!` in the middle of multiple `let`s' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject { User }
 

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   subject(:cop) { described_class.new }
 
   it 'flags multiple hooks in the same example group' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         before { bar }
         ^^^^^^^^^^^^^^ Do not define multiple hooks in the same example group.
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'flags multiple hooks of the same scope with different symbols' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         before { bar }
         ^^^^^^^^^^^^^^ Do not define multiple hooks in the same example group.
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'flags multiple before(:all) hooks in the same example group' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         before(:all) { bar }
         ^^^^^^^^^^^^^^^^^^^^ Do not define multiple hooks in the same example group.
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'does not flag different hooks' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         before { bar }
         after { baz }
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'does not flag different hook types' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         before { bar }
         before(:all) { baz }
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'does not flag hooks in different example groups' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         before { bar }
 
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'does not flag hooks in different shared contexts' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         shared_context 'one' do
           before { bar }
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'does not flag similar method names inside of examples' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         before { bar }
 

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -3,14 +3,14 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
 
   context 'shared_context' do
     it 'does not register an offense for empty contexts' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         shared_context 'empty' do
         end
       RUBY
     end
 
     it 'registers an offense for shared_context with only examples' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         shared_context 'foo' do
         ^^^^^^^^^^^^^^^^^^^^ Use `shared_examples` when you don't define context.
           it 'performs actions' do
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_context` with let' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         shared_context 'foo' do
           let(:foo) { :bar }
 
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_context` with subject' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         shared_context 'foo' do
           subject(:foo) { :bar }
 
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_context` with before' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         shared_context 'foo' do
           before do
             something
@@ -57,14 +57,14 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
 
   context 'shared_examples' do
     it 'does not register an offense for empty examples' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         shared_examples 'empty' do
         end
       RUBY
     end
 
     it 'registers an offense for shared_examples with only let' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           let(:foo) { :bar }
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'registers an offense for shared_examples with only subject' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           subject(:foo) { :bar }
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'registers an offense for shared_examples with only hooks' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           before do
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_examples` with it' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         shared_examples 'foo' do
           subject(:foo) { 'foo' }
           let(:bar) { :baz }

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
   describe 'receive_message_chain' do
     it 'reports single-argument calls' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before do
           allow(foo).to receive_message_chain(:one) { :two }
                         ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     )
 
     it 'accepts multi-argument calls' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before do
           allow(foo).to receive_message_chain(:one, :two) { :three }
         end
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'reports single-argument string calls' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before do
           allow(foo).to receive_message_chain("one") { :two }
                         ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     )
 
     it 'accepts multi-argument string calls' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before do
           allow(foo).to receive_message_chain("one.two") { :three }
         end
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
     context 'with single-key hash argument' do
       it 'reports an offence' do
-        expect_violation(<<-RUBY)
+        expect_offense(<<-RUBY)
           before do
             allow(foo).to receive_message_chain(bar: 42)
                           ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
     context 'with multiple keys hash argument' do
       it "doesn't report an offence" do
-        expect_no_violations(<<-RUBY)
+        expect_no_offenses(<<-RUBY)
           before do
             allow(foo).to receive_message_chain(bar: 42, baz: 42)
           end
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
   describe 'stub_chain' do
     it 'reports single-argument calls' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before do
           foo.stub_chain(:one) { :two }
               ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     )
 
     it 'accepts multi-argument calls' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before do
           foo.stub_chain(:one, :two) { :three }
         end
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'reports single-argument string calls' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         before do
           foo.stub_chain("one") { :two }
               ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     )
 
     it 'accepts multi-argument string calls' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         before do
           foo.stub_chain("one.two") { :three }
         end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   subject(:cop) { described_class.new }
 
   it 'complains when subject is stubbed' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'complains when subject is mocked' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'ignores stub within context where subject name changed' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs when nested subject uses same name' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'ignores nested stubs when nested subject is anonymous' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs when example group does not define subject' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs when adjacent context redefines' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -159,7 +159,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags deeply nested subject stubs' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'finds a `double` instead of an `instance_double`' do
-    expect_violation(<<-RUBY)
+    expect_offense(<<-RUBY)
       it do
         foo = double("Widget")
               ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     let(:cop_config) { {} }
 
     it 'find doubles whose name is a symbol' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
           foo = double(:widget)
                 ^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     end
 
     it 'finds a `spy` instead of an `instance_spy`' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
           foo = spy("Widget")
                 ^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     let(:cop_config) { { 'IgnoreSymbolicNames' => true } }
 
     it 'ignores doubles whose name is a symbol' do
-      expect_no_violations(<<-RUBY)
+      expect_no_offenses(<<-RUBY)
         it do
           foo = double(:widget)
         end
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     end
 
     it 'still flags doubles whose name is a string' do
-      expect_violation(<<-RUBY)
+      expect_offense(<<-RUBY)
         it do
           foo = double("widget")
                 ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   end
 
   it 'ignores doubles without a name' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it do
         foo = double
       end
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   end
 
   it 'ignores instance_doubles' do
-    expect_no_violations(<<-RUBY)
+    expect_no_offenses(<<-RUBY)
       it do
         foo = instance_double("Foo")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
   # We should take their advice!
   config.raise_on_warning = true
 
-  config.include(ExpectViolation)
+  config.include(ExpectOffense)
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
I'd like to upstream this to RuboCop soon!

 - Drops dependency on concord
 - Drops dependency on anima
 - Drops dependency on adamantium

See also bbatsov/rubocop#3905