### PR TITLE
Forbids dynamic attributes defined statically on factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add `RSpec/FactoryGirl` namespace including the first cop for factories: `FactoryGirl/DynamicAttributeDefinedStatically`. ([@jonatas][])
+
 ## 1.15.1 (2017-04-30)
 
 * Fix the handling of various edge cases in the `RSpec/ExampleWording` cop, including one that would cause autocorrect to crash. ([@dgollahon][])
@@ -218,3 +220,4 @@
 [@cfabianski]: https://github.com/cfabianski
 [@dgollahon]: https://github.com/dgollahon
 [@tsigo]: https://github.com/tsigo
+[@jonatas]: https://github.com/jonatas

--- a/bin/build_config
+++ b/bin/build_config
@@ -8,7 +8,8 @@ require 'rubocop-rspec'
 require 'rubocop/rspec/description_extractor'
 require 'rubocop/rspec/config_formatter'
 
-glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec', '*.rb')
+cops = '{*.rb,factory_girl/*.rb}'
+glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec', cops)
 YARD.parse(Dir[glob], [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,10 @@ AllCops:
     Patterns:
     - _spec.rb
     - "(?:^|/)spec/"
+  RSpec/FactoryGirl:
+    Patterns:
+    - spec/factories/**/*.rb
+    - features/support/factories/**/*.rb
 
 RSpec/AnyInstance:
   Description: Check that instances are not being stubbed globally.
@@ -224,3 +228,7 @@ RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
   Enabled: true
   IgnoreSymbolicNames: false
+
+FactoryGirl/DynamicAttributeDefinedStatically:
+  Description: Prefer declaring dynamic attribute values in a block.
+  Enabled: true

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -16,6 +16,7 @@ require 'rubocop/rspec/example_group'
 require 'rubocop/rspec/example'
 require 'rubocop/rspec/hook'
 require 'rubocop/cop/rspec/cop'
+require 'rubocop/rspec/factory_girl'
 
 RuboCop::RSpec::Inject.defaults!
 
@@ -35,6 +36,7 @@ require 'rubocop/cop/rspec/example_length'
 require 'rubocop/cop/rspec/example_wording'
 require 'rubocop/cop/rspec/expect_actual'
 require 'rubocop/cop/rspec/expect_output'
+require 'rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically'
 require 'rubocop/cop/rspec/file_path'
 require 'rubocop/cop/rspec/focus'
 require 'rubocop/cop/rspec/hook_argument'

--- a/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module FactoryGirl
+        # Prefer declaring dynamic attribute values in a block.
+        #
+        # @example
+        #   # bad
+        #   kind [:active, :rejected].sample
+        #
+        #   # good
+        #   kind { [:active, :rejected].sample }
+        #
+        #   # bad
+        #   closed_at 1.day.from_now
+        #
+        #   # good
+        #   closed_at { 1.day.from_now }
+        #
+        #   # good
+        #   kind :static
+        #
+        #   # good
+        #   comments_count 0
+        #
+        #   # good
+        #   type User::MAGIC
+        class DynamicAttributeDefinedStatically < Cop
+          MSG = 'Use a block to set a dynamic value to an attribute.'.freeze
+
+          def_node_matcher :dynamic_defined_statically?, <<-PATTERN
+          (send nil _ (send ... ))
+          PATTERN
+
+          def_node_search :factory_attributes, <<-PATTERN
+          (block (send nil {:factory, :trait} ...) _ { (begin $...) $(send ...) } )
+          PATTERN
+
+          def on_block(node)
+            return if node.method_name == :trait
+            factory_attributes(node).to_a.flatten.each do |attribute|
+              if dynamic_defined_statically?(attribute)
+                add_offense(attribute, :expression)
+              end
+            end
+          end
+
+          def autocorrect(node)
+            if method_uses_parens?(node.location)
+              autocorrect_replacing_parens(node)
+            else
+              autocorrect_without_parens(node)
+            end
+          end
+
+          private
+
+          def method_uses_parens?(location)
+            return false unless location.begin && location.end
+            location.begin.source == '(' && location.end.source == ')'
+          end
+
+          def autocorrect_replacing_parens(node)
+            lambda do |corrector|
+              corrector.replace(node.location.begin, ' { ')
+              corrector.replace(node.location.end, ' }')
+            end
+          end
+
+          def autocorrect_without_parens(node)
+            lambda do |corrector|
+              arguments = node.descendants.first
+              expression = arguments.location.expression
+              corrector.insert_before(expression, '{ ')
+              corrector.insert_after(expression, ' }')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
-      NAMESPACE = 'RSpec'.freeze
+      NAMESPACES = /^(#{Regexp.union('RSpec', 'FactoryGirl')})/
 
       def initialize(config, descriptions)
         @config       = config
@@ -12,7 +12,7 @@ module RuboCop
       end
 
       def dump
-        YAML.dump(unified_config).gsub(/^#{NAMESPACE}/, "\n#{NAMESPACE}")
+        YAML.dump(unified_config).gsub(NAMESPACES, "\n\\1")
       end
 
       private
@@ -24,7 +24,7 @@ module RuboCop
       end
 
       def cops
-        (descriptions.keys + config.keys).uniq.grep(/\A#{NAMESPACE}/)
+        (descriptions.keys | config.keys).grep(NAMESPACES)
       end
 
       attr_reader :config, :descriptions

--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -19,7 +19,7 @@ module RuboCop
 
       # Decorator of a YARD code object for working with documented rspec cops
       class CodeObject
-        COP_NAMESPACE = 'RuboCop::Cop::RSpec'.freeze
+        RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'.freeze
 
         def initialize(yardoc)
           @yardoc = yardoc
@@ -54,7 +54,7 @@ module RuboCop
         end
 
         def rspec_cop_namespace?
-          documented_constant.start_with?(COP_NAMESPACE)
+          documented_constant.start_with?(RSPEC_NAMESPACE)
         end
 
         def documented_constant

--- a/lib/rubocop/rspec/factory_girl.rb
+++ b/lib/rubocop/rspec/factory_girl.rb
@@ -1,0 +1,7 @@
+module RuboCop
+  module RSpec
+    # RuboCop FactoryGirl project namespace
+    module FactoryGirl
+    end
+  end
+end

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe 'config/default.yml' do
   end
 
   let(:cop_names) do
-    glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'rspec', '*.rb')
-
+    namespaces = {
+      'rspec' => 'RSpec',
+      'factory_girl' => 'FactoryGirl'
+    }
+    glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop',
+                                 'rspec', '{,factory_girl/}*.rb')
     cop_names =
       Pathname.glob(glob).map do |file|
         file_name = file.basename('.rb').to_s
         cop_name  = file_name.gsub(/(^|_)(.)/) { Regexp.last_match(2).upcase }
-
-        "RSpec/#{cop_name}"
+        namespace = namespaces[file.dirname.basename.to_s]
+        "#{namespace}/#{cop_name}"
       end
 
     cop_names - %w[RSpec/Cop]

--- a/spec/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/LineLength
+RSpec.describe RuboCop::Cop::RSpec::FactoryGirl::DynamicAttributeDefinedStatically do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense for offending code' do
+    expect_offense(<<-RUBY)
+      FactoryGirl.define do
+        factory :post do
+          published_at 1.day.from_now
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
+          status [:draft, :published].sample
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
+          created_at 1.day.ago
+          ^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense in a trait' do
+    expect_offense(<<-RUBY)
+      FactoryGirl.define do
+        factory :post do
+          title "Something"
+          trait :published do
+            published_at 1.day.from_now
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts' do
+    expect_no_offenses(<<-RUBY)
+      FactoryGirl.define do
+        factory :post do
+          trait :published do
+            published_at { 1.day.from_now }
+          end
+          created_at { 1.day.ago }
+          status :draft
+          comments_count 0
+          title "Static"
+          description { FFaker::Lorem.paragraph(10) }
+          tag Tag::MAGIC
+        end
+      end
+    RUBY
+  end
+
+  it 'does not add offense if out of factory girl block' do
+    expect_no_offenses(<<-RUBY)
+      status [:draft, :published].sample
+      published_at 1.day.from_now
+      created_at 1.day.ago
+    RUBY
+  end
+
+  bad = <<-RUBY
+    FactoryGirl.define do
+      factory :post do
+        status([:draft, :published].sample)
+        published_at 1.day.from_now
+        created_at(1.day.ago)
+        updated_at Time.current
+      end
+    end
+  RUBY
+
+  corrected = <<-RUBY
+    FactoryGirl.define do
+      factory :post do
+        status { [:draft, :published].sample }
+        published_at { 1.day.from_now }
+        created_at { 1.day.ago }
+        updated_at { Time.current }
+      end
+    end
+  RUBY
+
+  include_examples 'autocorrect', bad, corrected
+end


### PR DESCRIPTION
I proposed it in #393.

It complains against nonstatic attributes declared statically without being wrapped in a block.

The idea is to cover cases like:

```ruby
# bad
kind [:active, :rejected].sample
# good
kind { [:active, :rejected].sample }

# bad
closed_at 1.day.from_now
# good
closed_at { 1.day.from_now }

# good
kind :static

# good
comments_count 0

# good
type User::MAGIC
```

