### PR TITLE
Refactor ExpectOffense implementation

### DIFF
--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the source path ends with `_spec.rb`' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, filename: 'foo_spec.rb')
+      expect_offense(<<-RUBY, 'foo_spec.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
     end
 
     it 'ignores the file if it is ignored' do
-      expect_no_offenses(<<-RUBY, filename: 'bar_spec.rb')
+      expect_no_offenses(<<-RUBY, 'bar_spec.rb')
         foo(1)
       RUBY
     end
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the source path contains `/spec/`' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, filename: '/spec/support/thing.rb')
+      expect_offense(<<-RUBY, '/spec/support/thing.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the source path starts with `spec/`' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, filename: 'spec/support/thing.rb')
+      expect_offense(<<-RUBY, 'spec/support/thing.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
@@ -71,13 +71,13 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   context 'when the file is a source file without "spec" in the name' do
     it 'ignores the source when the path is not a spec file' do
-      expect_no_offenses(<<-RUBY, filename: 'foo.rb')
+      expect_no_offenses(<<-RUBY, 'foo.rb')
         foo(1)
       RUBY
     end
 
     it 'ignores the source when the path is not a specified pattern' do
-      expect_no_offenses(<<-RUBY, filename: 'foo_test.rb')
+      expect_no_offenses(<<-RUBY, 'foo_test.rb')
         foo(1)
       RUBY
     end
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
     end
 
     it 'registers offenses when the path matches a custom specified pattern' do
-      expect_offense(<<-RUBY, filename: 'foo_test.rb')
+      expect_offense(<<-RUBY, 'foo_test.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -2,170 +2,170 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for a bad path' do
-    expect_offense(<<-RUBY, filename: 'wrong_path_foo_spec.rb')
+    expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
       describe MyClass, 'foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class but a correct method' do
-    expect_offense(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
+    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a repeated .rb' do
-    expect_offense(<<-RUBY, filename: 'my_class/foo_spec.rb.rb')
+    expect_offense(<<-RUBY, 'my_class/foo_spec.rb.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file missing a .rb' do
-    expect_offense(<<-RUBY, filename: 'my_class/foo_specorb')
+    expect_offense(<<-RUBY, 'my_class/foo_specorb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class and highlights metadata' do
-    expect_offense(<<-RUBY, filename: 'wrong_class_foo_spec.rb')
+    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo', blah: :blah do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class name' do
-    expect_offense(<<-RUBY, filename: 'wrong_class_spec.rb')
+    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
       describe MyClass do; end
       ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class name with a symbol argument' do
-    expect_offense(<<-RUBY, filename: 'wrong_class_spec.rb')
+    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
       describe MyClass, :foo do; end
       ^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file missing _spec' do
-    expect_offense(<<-RUBY, filename: 'user.rb')
+    expect_offense(<<-RUBY, 'user.rb')
       describe User do; end
       ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
     RUBY
   end
 
   it 'skips specs that do not describe a class / method' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class/spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end
     RUBY
   end
 
   it 'skips specs that do have multiple top level describes' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class/spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe MyClass, 'do_this' do; end
       describe MyClass, 'do_that' do; end
     RUBY
   end
 
   it 'checks class specs' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'allows different parent directories' do
-    expect_no_offenses(<<-RUBY, filename: 'parent_dir/some/class_spec.rb')
+    expect_no_offenses(<<-RUBY, 'parent_dir/some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'handles CamelCaps class names' do
-    expect_no_offenses(<<-RUBY, filename: 'my_class_spec.rb')
+    expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
       describe MyClass do; end
     RUBY
   end
 
   it 'handles ACRONYMClassNames' do
-    expect_no_offenses(<<-RUBY, filename: 'abc_one/two_spec.rb')
+    expect_no_offenses(<<-RUBY, 'abc_one/two_spec.rb')
       describe ABCOne::Two do; end
     RUBY
   end
 
   it 'handles ALLCAPS class names' do
-    expect_no_offenses(<<-RUBY, filename: 'allcaps_spec.rb')
+    expect_no_offenses(<<-RUBY, 'allcaps_spec.rb')
       describe ALLCAPS do; end
     RUBY
   end
 
   it 'handles alphanumeric class names' do
-    expect_no_offenses(<<-RUBY, filename: 'ipv4_and_ipv6_spec.rb')
+    expect_no_offenses(<<-RUBY, 'ipv4_and_ipv6_spec.rb')
       describe IPV4AndIPV6 do; end
     RUBY
   end
 
   it 'checks instance methods' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class/inst_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'checks class methods' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class/inst_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'allows flat hierarchies for instance methods' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class_inst_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'allows flat hierarchies for class methods' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class_inst_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'allows subdirs for instance methods' do
     filename = 'some/class/instance_methods/inst_spec.rb'
-    expect_no_offenses(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'allows subdirs for class methods' do
     filename = 'some/class/class_methods/inst_spec.rb'
-    expect_no_offenses(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'ignores non-alphanumeric characters' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class/pred_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class/pred_spec.rb')
       describe Some::Class, '#pred?' do; end
     RUBY
   end
 
   it 'allows bang method' do
-    expect_no_offenses(<<-RUBY, filename: 'some/class/bang_spec.rb')
+    expect_no_offenses(<<-RUBY, 'some/class/bang_spec.rb')
       describe Some::Class, '#bang!' do; end
     RUBY
   end
 
   it 'allows flexibility with predicates' do
     filename = 'some/class/thing_predicate_spec.rb'
-    expect_no_offenses(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '#thing?' do; end
     RUBY
   end
 
   it 'allows flexibility with operators' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
-    expect_no_offenses(<<-RUBY, filename: filename)
+    expect_no_offenses(<<-RUBY, filename)
       describe MyLittleClass, '#<=>' do; end
     RUBY
   end
@@ -174,13 +174,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
     it 'respects custom module name transformation' do
-      expect_no_offenses(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
         describe FooFoo::Some::Class, '#bar' do; end
       RUBY
     end
 
     it 'ignores routing specs' do
-      expect_no_offenses(<<-RUBY, filename: 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
         describe MyController, "#foo", type: :routing do; end
       RUBY
     end
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 
     it 'does not care about the described method' do
-      expect_no_offenses(<<-RUBY, filename: 'my_class_spec.rb')
+      expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
         describe MyClass, '#look_here_a_method' do; end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
 
   # Regression test for nevir/rubocop-rspec#115
   it 'ignores instance variables outside of specs' do
-    expect_no_offenses(<<-RUBY, filename: 'lib/source_code.rb')
+    expect_no_offenses(<<-RUBY, 'lib/source_code.rb')
       feature do
         @foo = bar
 


### PR DESCRIPTION
I have been reworking this code so that I can upstream it to RuboCopproper. See bbatsov/rubocop#4337

This implementation is much simpler. We simply split out the annotation lines from the source and initialize an `AnnotatedSource` object. We can provide an array of offenses to the `AnnotatedSource` instance and get back a new `AnnotatedSource` instance representing the real offenses. `AnnotatedSource` instances then generate an annotated source string (just like what is provided to the matcher) so we can compare the strings and get a nice RSpec diff in the output if they don't match.

Way simpler AND way nicer to work with thanks to RSpec's diffs.