### PR TITLE
Add auto-correct support to ReturnFromStub cop

### DIFF
--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -7,9 +7,9 @@ module RuboCop
       #
       # Enforces either `and_return` or block-style return in the cases
       # where the returned value is constant. Ignores dynamic returned values
-      # are the result would be different
+      # as the result would be different.
       #
-      # This cop can be configured using the `EnforcedStyle` option
+      # This cop can be configured using the `EnforcedStyle` option.
       #
       # @example `EncorcedStyle: block`
       #   # bad
@@ -68,6 +68,16 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            if style == :and_return
+              autocorrect_block_to_method(node, corrector)
+            else
+              autocorrect_method_to_block(node, corrector)
+            end
+          end
+        end
+
         private
 
         def dynamic?(node)
@@ -76,6 +86,36 @@ module RuboCop
           end
 
           !node.literal?
+        end
+
+        def autocorrect_block_to_method(node, corrector)
+          receive_with_block(node) do |args|
+            replacement = ".and_return(#{args.source})"
+            corrector.replace(block_range_with_space(node), replacement)
+          end
+        end
+
+        def autocorrect_method_to_block(node, corrector)
+          receive, _and_return, value = *node
+          replacement = "#{receive.source} { #{value.source} }"
+          corrector.replace(node.loc.expression, replacement)
+        end
+
+        def block_range_with_space(node)
+          block_range = range_between(begin_pos_for_replacement(node),
+                                      node.loc.end.end_pos)
+          range_with_surrounding_space(block_range, :left)
+        end
+
+        def begin_pos_for_replacement(node)
+          block_send_or_super, _block_args, _block_body = *node
+          expr = block_send_or_super.source_range
+
+          if (paren_pos = (expr.source =~ /\(\s*\)$/))
+            expr.begin_pos + paren_pos
+          else
+            node.loc.begin.begin_pos
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
         end
       RUBY
     end
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar) { 42 }',
+                     'allow(Foo).to receive(:bar).and_return(42)'
   end
 
   context 'with EnforcedStyle `block`' do
@@ -81,5 +85,9 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
         end
       RUBY
     end
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).and_return(42)',
+                     'allow(Foo).to receive(:bar) { 42 }'
   end
 end


### PR DESCRIPTION
With little digging (and copying) in the Rubocop source, I've managed to implement auto-correct support for the new ReturnFromStub cop.