### PR TITLE
Drop comma in def_node_search

### DIFF
--- a/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
@@ -35,7 +35,7 @@ module RuboCop
           PATTERN
 
           def_node_search :factory_attributes, <<-PATTERN
-          (block (send nil {:factory, :trait} ...) _ { (begin $...) $(send ...) } )
+          (block (send nil {:factory :trait} ...) _ { (begin $...) $(send ...) } )
           PATTERN
 
           def on_block(node)


### PR DESCRIPTION
In bbatsov/rubocop's master branch, comma is not allowed in node pattern.

See. https://github.com/bbatsov/rubocop/pull/4499