### PR TITLE
Suppress a warning of redefined method

### DIFF
--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -5,9 +5,11 @@ module RuboCop
     # Clone of the the normal RuboCop::Cop::Cop class so we can rewrite
     # the inherited method without breaking functionality
     class WorkaroundCop
-      # Overwrite the cop inherited method to be a noop. Our RSpec::Cop
+      # Remove the cop inherited method to be a noop. Our RSpec::Cop
       # class will invoke the inherited hook instead
-      def self.inherited(*); end
+      class << self
+        remove_method :inherited
+      end
 
       # Special case `Module#<` so that the rspec support rubocop exports
       # is compatible with our subclass


### PR DESCRIPTION
MRI warns about `method redefined`.

```bash
$ ruby -w -Ilib -rrubocop-rspec -e ''
...
/home/pocke/ghq/github.com/backus/rubocop-rspec/lib/rubocop/cop/rspec/cop.rb:10: warning: method redefined; discarding old inherited
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/lib/rubocop/cop/cop.rb:55: warning: previous definition of inherited was here
```

This change suppresses the warning.

Note: It uses `remove_method` instead of `undef`. If `undef` is used, the class raises a NameError.

```ruby
class A
  def self.inherited(*)
    puts 'inherited'
  end
end

B = A

class B
  class << self
    remove_method :inherited
  end
end

class C < B # it does not raise error.
end
```

```
class A
  def self.inherited(*)
    puts 'inherited'
  end
end

B = A

class B
  class << self
    undef inherited
  end
end

class C < B # => undefined method `inherited' for A:Class (NoMethodError)
end
```