### PR TITLE
Use eval_gemfile instead of eval

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ end
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)
-  eval(File.read(local_gemfile)) # rubocop:disable Security/Eval
+  eval_gemfile(local_gemfile)
 end


### PR DESCRIPTION
Bundler has a method `eval_gemfile` that allows to *not* call `eval` in our Gemfile.