### PR TITLE
Add new `RSpec/VoidExpect` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `RSpec/LetBeforeExamples` cop. ([@Darhazer][])
 * Add `RSpec/MultipleSubjects` cop. ([@backus][])
 * Add `RSpec/ReturnFromStub` cop. ([@Darhazer][])
+* Add `RSpec/VoidExpect` cop. ([@pocke][])
 
 ## 1.15.1 (2017-04-30)
 
@@ -226,3 +227,4 @@
 [@dgollahon]: https://github.com/dgollahon
 [@tsigo]: https://github.com/tsigo
 [@jonatas]: https://github.com/jonatas
+[@pocke]: https://github.com/pocke

--- a/config/default.yml
+++ b/config/default.yml
@@ -300,6 +300,11 @@ RSpec/VerifiedDoubles:
   IgnoreSymbolicNames: false
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 
+RSpec/VoidExpect:
+  Description: This cop checks void `expect()`.
+  Enabled: true
+  StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
+
 FactoryGirl/DynamicAttributeDefinedStatically:
   Description: Prefer declaring dynamic attribute values in a block.
   Enabled: true

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -70,6 +70,7 @@ require 'rubocop/cop/rspec/shared_context'
 require 'rubocop/cop/rspec/single_argument_message_chain'
 require 'rubocop/cop/rspec/subject_stub'
 require 'rubocop/cop/rspec/verified_doubles'
+require 'rubocop/cop/rspec/void_expect'
 
 # We have to register our autocorrect incompatibilies in RuboCop's cops as well
 # so we do not hit infinite loops

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # This cop checks void `expect()`.
+      #
+      # @example
+      #   # bad
+      #   expect(something)
+      #
+      #   # good
+      #   expect(something).to be(1)
+      class VoidExpect < Cop
+        MSG = 'Do not use `expect()` without `.to` or `.not_to`. ' \
+              'Chain the methods or remove it.'.freeze
+
+        def_node_matcher :expect?, <<-PATTERN
+          (send nil :expect ...)
+        PATTERN
+
+        def_node_matcher :expect_block?, <<-PATTERN
+          (block #expect? (args) _body)
+        PATTERN
+
+        def on_send(node)
+          return unless expect?(node)
+          check_expect(node)
+        end
+
+        def on_block(node)
+          return unless expect_block?(node)
+          check_expect(node)
+        end
+
+        private
+
+        def check_expect(node)
+          return unless void?(node)
+          add_offense(node, :expression)
+        end
+
+        def void?(expect)
+          parent = expect.parent
+          return true unless parent
+          return true if parent.begin_type?
+          return true if parent.block_type? && parent.children[2] == expect
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/void_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/void_expect_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
+  subject(:cop) { described_class.new }
+
+  it 'registers offenses to void `expect`' do
+    expect_offense(<<-RUBY)
+      it 'something' do
+        something = 1
+        expect(something)
+        ^^^^^^^^^^^^^^^^^ Do not use `expect()` without `.to` or `.not_to`. Chain the methods or remove it.
+      end
+    RUBY
+  end
+
+  it 'registers offenses to void `expect` when block has one expression' do
+    expect_offense(<<-RUBY)
+      it 'something' do
+        expect(something)
+        ^^^^^^^^^^^^^^^^^ Do not use `expect()` without `.to` or `.not_to`. Chain the methods or remove it.
+      end
+    RUBY
+  end
+
+  it 'registers offenses to void `expect` with block' do
+    expect_offense(<<-RUBY)
+      it 'something' do
+        expect{something}
+        ^^^^^^^^^^^^^^^^^ Do not use `expect()` without `.to` or `.not_to`. Chain the methods or remove it.
+      end
+    RUBY
+  end
+
+  it 'accepts non-void `expect`' do
+    expect_no_offenses(<<-RUBY)
+      it 'something' do
+        expect(something).to be 1
+      end
+    RUBY
+  end
+
+  it 'accepts non-void `expect` with block' do
+    expect_no_offenses(<<-RUBY)
+      it 'something' do
+        expect{something}.to raise_error(StandardError)
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This cop checks void `expect()` usage.

If `expect()` is used without `.to()` or `.not_to()`, the `expect()` does not make sense. But RSpec does not raise error / warning.


For example:


```ruby
it 'something' do
  # bad: it does nothing.
  expect(something)
end
```


This cop checks the problem.