### PR TITLE
Drop a comma from node pattern

### DIFF
--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -154,7 +154,7 @@ module RuboCop
         def_node_matcher :predicate_matcher_block?, <<-PATTERN
           (block
             (send
-              (send nil :expect, $!nil)
+              (send nil :expect $!nil)
               {:to :not_to :to_not}
               $(send nil #predicate_matcher_name?))
             ...)


### PR DESCRIPTION
Ref: #434 

This comma is unnecessary. Sorry it is my mistake.