### PR TITLE
Count is_expected towards expectations count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add `RSpec/PredicateMatcher` cop. ([@pocke][])
 * Add `RSpec/ExpectInHook` cop. ([@pocke][])
 * `RSpec/MultipleExpectations` now detects usage of expect_any_instance_of. ([@Darhazer][])
+* `RSpec/MultipleExpectations` now detects usage of is_expected. ([@bmorrall][])
 
 ## 1.15.1 (2017-04-30)
 
@@ -233,3 +234,4 @@
 [@tsigo]: https://github.com/tsigo
 [@jonatas]: https://github.com/jonatas
 [@pocke]: https://github.com/pocke
+[@bmorrall]: https:/github.com/bmorrall

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -107,7 +107,7 @@ module RuboCop
       end
 
       module Expectations
-        ALL = SelectorSet.new(%i[expect expect_any_instance_of])
+        ALL = SelectorSet.new(%i[expect is_expected expect_any_instance_of])
       end
 
       ALL =

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       before do
         expect(something).to eq('foo')
         ^^^^^^ Do not use `expect` in `before` hook
+        is_expected.to eq('foo')
+        ^^^^^^^^^^^ Do not use `is_expected` in `before` hook
         expect_any_instance_of(Something).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `before` hook
       end
@@ -19,6 +21,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       after do
         expect(something).to eq('foo')
         ^^^^^^ Do not use `expect` in `after` hook
+        is_expected.to eq('foo')
+        ^^^^^^^^^^^ Do not use `is_expected` in `after` hook
         expect_any_instance_of(Something).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `after` hook
       end
@@ -30,6 +34,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       around do
         expect(something).to eq('foo')
         ^^^^^^ Do not use `expect` in `around` hook
+        is_expected(something).to eq('foo')
+        ^^^^^^^^^^^ Do not use `is_expected` in `around` hook
         expect_any_instance_of(Something).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `around` hook
       end
@@ -65,6 +71,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
     expect_no_offenses(<<-RUBY)
       it do
         expect(something).to eq('foo')
+        is_expected.to eq('foo')
         expect_any_instance_of(something).to receive(:foo)
       end
     RUBY

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       RUBY
     end
 
+    it 'flags multiple is_expected' do
+      expect_offense(<<-RUBY)
+        describe Foo do
+          it 'uses expect_any_instance_of twice' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            is_expected.to receive(:bar)
+            is_expected.to receive(:baz)
+          end
+        end
+      RUBY
+    end
+
     it 'flags multiple expects with blocks' do
       expect_offense(<<-RUBY)
         describe Foo do


### PR DESCRIPTION
Fixes #448 

Used recent changes from @Darhazer to add `is_expected` to the list of possible expectation matcher.

Let me know if anything needs to be changed.