### PR TITLE
Bump version to 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.16.0 (2017-09-06)
+
 * Add `RSpec/FactoryGirl` namespace including the first cop for factories: `FactoryGirl/DynamicAttributeDefinedStatically`. ([@jonatas][])
 * Add disabled by default `RSpec/AlignLeftLetBrace`. ([@backus][])
 * Add disabled by default `RSpec/AlignRightLetBrace`. ([@backus][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.15.1'.freeze
+      STRING = '1.16.0'.freeze
     end
   end
 end


### PR DESCRIPTION
We didn't have a release for a while and there's a lot of cops added.

@backus @dgollahon as I don't have access to RubyGems, can you please push the new version there?