### PR TITLE
Fix for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.2.5
   - 2.3.1
   - ruby-head
+  - jruby-9.1.13.0
 
 matrix:
   allow_failures:

--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -5,10 +5,11 @@ module RuboCop
     # Clone of the the normal RuboCop::Cop::Cop class so we can rewrite
     # the inherited method without breaking functionality
     class WorkaroundCop
-      # Remove the cop inherited method to be a noop. Our RSpec::Cop
+      # Remove the Cop.inherited method to be a noop. Our RSpec::Cop
       # class will invoke the inherited hook instead
       class << self
-        remove_method :inherited
+        undef inherited
+        def inherited(*) end
       end
 
       # Special case `Module#<` so that the rspec support rubocop exports


### PR DESCRIPTION
JRuby support was broken at 1.16.0, and nobody noticed because `.travis.yml` doesn't include JRuby.
If it is not a principal position of the team, please merge this to fix both problems :)