### PR TITLE
Fix ReturnFromStub crashing on a stub in a method

### DIFF
--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -62,7 +62,10 @@ module RuboCop
         end
 
         def check_block_body(node)
-          _receiver, _args, body = *node.each_ancestor(:block).first
+          block = node.each_ancestor(:block).first
+          return unless block
+
+          _receiver, _args, body = *block
           add_offense(node, :expression, MSG_AND_RETURN) unless dynamic?(body)
         end
 

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -90,6 +90,22 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
         end
       RUBY
     end
+
+    it 'ignores stubs without return value' do
+      expect_no_offenses(<<-RUBY)
+        it do
+          allow(Foo).to receive(:bar)
+        end
+      RUBY
+    end
+
+    it 'handles stubs in a method' do
+      expect_no_offenses(<<-RUBY)
+        def stub_foo
+          allow(Foo).to receive(:bar)
+        end
+      RUBY
+    end
   end
 
   context 'with EnforcedStyle `block`' do


### PR DESCRIPTION
@bquorning 
#458 missed one edge-case. When searching for the enclosing block of a stub calling `receive`, in case the stub does not have block (not returning value or using `on_return`) it would match the first block in the ancestors chain, e.g. `it`. It would not give false positive just because the `receive` call itself is a dynamic one, and we ignore dynamic calls in the block. 
It's possible however to have a stub without a block in the ancestor chain, e.g. in a class/module with helper methods. This was giving ```undefined method `recursive_literal?' for nil:NilClass```.