### PR TITLE
Fix false positives in Capybara/Feature cop. Fixes #468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix false positive in `Capybara/FeatureMethods`. ([@Darhazer][])
+
 ## 1.17.1 (2017-09-20)
 
 * Improved `RSpec/ReturnFromStub` to handle string interpolation, hashes and do..end blocks. ([@Darhazer][])

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -45,13 +45,15 @@ module RuboCop
             feature:    :describe
           }.freeze
 
-          def_node_matcher :feature_method?, <<-PATTERN
-            (send {(const nil :RSpec) nil} ${:#{MAP.keys.join(' :')}} ...)
+          def_node_matcher :feature_method, <<-PATTERN
+            (block
+              $(send {(const nil :RSpec) nil} ${#{MAP.keys.map(&:inspect).join(' ')}} ...)
+            ...)
           PATTERN
 
-          def on_send(node)
-            feature_method?(node) do |match|
-              add_offense(node, :selector, format(MSG, MAP[match], match))
+          def on_block(node)
+            feature_method(node) do |send_node, match|
+              add_offense(send_node, :selector, format(MSG, MAP[match], match))
             end
           end
 

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
+  it 'ignores variables inside examples' do
+    expect_no_offenses(<<-RUBY)
+      it 'is valid code' do
+        given(feature)
+        assign(background)
+        run scenario
+      end
+    RUBY
+  end
+
   include_examples 'autocorrect', 'background { }',    'before { }'
   include_examples 'autocorrect', 'scenario { }',      'it { }'
   include_examples 'autocorrect', 'xscenario { }',     'xit { }'


### PR DESCRIPTION
@rspeicher @bquorning 

Generally we should add some common tests, as mentioned earlier by @backus, or at least some guidelines, in order to check for such errors (false positive when the searched token is mentioned inside the example, empty examples group or so on)