### PR TITLE
Don't check single-line example blocks. Fixes #456

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix false positive in `Capybara/FeatureMethods`. ([@Darhazer][])
 * Add `RSpec/Capybara/CurrentPathExpectation` cop for feature specs, disallowing setting expectations on `current_path`. ([@timrogers][])
+* Fix false positive in `RSpec/LetBeforeExamples` cop when example group contains single let. ([@Darhazer][])
 
 ## 1.17.1 (2017-09-20)
 

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -44,9 +44,13 @@ module RuboCop
         def on_block(node)
           return unless example_group_with_body?(node)
 
-          _describe, _args, body = *node
+          check_let_declarations(node.body) if multiline_block?(node.body)
+        end
 
-          check_let_declarations(body)
+        private
+
+        def multiline_block?(block)
+          block.begin_type?
         end
 
         def check_let_declarations(node)

--- a/spec/rubocop/cop/rspec/let_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/let_before_examples_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
     RUBY
   end
 
+  it 'ignores single-line example blocks' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe User do
+        include_examples 'special user' do
+          let(:foo) { bar }
+        end
+      end
+    RUBY
+  end
+
   it 'does not encounter an error when handling an empty describe' do
     expect { inspect_source('RSpec.describe(User) do end', 'a_spec.rb') }
       .not_to raise_error


### PR DESCRIPTION
When the example has single line, the `let` becomes sibling on the `include_examples`, hence the false positive while checking the `describe` block.
When the `let` is the only node in the block however, there is no way it can be before another example