### PR TITLE
Use `nil?` instead of `nil` to match nil value in AST in node pattern

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -29,7 +29,7 @@ module RuboCop
                          'or `%<arg>s.run`.'.freeze
 
         def_node_matcher :hook, <<-PATTERN
-          (block {(send nil :around) (send nil :around sym)} (args $...) ...)
+          (block {(send nil? :around) (send nil? :around sym)} (args $...) ...)
         PATTERN
 
         def_node_search :find_arg_usage, <<-PATTERN

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -37,7 +37,7 @@ module RuboCop
         MSG = 'Prefer `be` over `eql`.'.freeze
 
         def_node_matcher :eql_type_with_identity, <<-PATTERN
-          (send _ :to $(send nil :eql {true false int float sym nil_type?}))
+          (send _ :to $(send nil? :eql {true false int float sym nil_type?}))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -27,7 +27,7 @@ module RuboCop
                 '`have_current_path` matcher on `page`'.freeze
 
           def_node_matcher :expectation_set_on_current_path, <<-PATTERN
-            (send nil :expect (send {(send nil :page) nil} :current_path))
+            (send nil? :expect (send {(send nil? :page) nil?} :current_path))
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -47,7 +47,7 @@ module RuboCop
 
           def_node_matcher :feature_method, <<-PATTERN
             (block
-              $(send {(const nil :RSpec) nil} ${#{MAP.keys.map(&:inspect).join(' ')}} ...)
+              $(send {(const nil? :RSpec) nil?} ${#{MAP.keys.map(&:inspect).join(' ')}} ...)
             ...)
           PATTERN
 

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -23,11 +23,11 @@ module RuboCop
               'the class or module being tested.'.freeze
 
         def_node_matcher :valid_describe?, <<-PATTERN
-          {(send {(const nil :RSpec) nil} :describe const ...) (send nil :describe)}
+          {(send {(const nil? :RSpec) nil?} :describe const ...) (send nil? :describe)}
         PATTERN
 
         def_node_matcher :describe_with_metadata, <<-PATTERN
-          (send {(const nil :RSpec) nil} :describe
+          (send {(const nil? :RSpec) nil?} :describe
             !const
             ...
             (hash $...))
@@ -40,7 +40,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :shared_group?, <<-PATTERN
-          (block (send {(const nil :RSpec) nil} #{SharedGroups::ALL.node_pattern_union} ...) ...)
+          (block (send {(const nil? :RSpec) nil?} #{SharedGroups::ALL.node_pattern_union} ...) ...)
         PATTERN
 
         def on_top_level_describe(node, args)

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Avoid describing symbols.'.freeze
 
         def_node_matcher :describe_symbol?, <<-PATTERN
-          (send {(const nil :RSpec) nil} :describe $sym ...)
+          (send {(const nil? :RSpec) nil?} :describe $sym ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -40,7 +40,7 @@ module RuboCop
         MSG             = 'Use `%s` instead of `%s`.'.freeze
 
         def_node_matcher :common_instance_exec_closure?, <<-PATTERN
-          (block (send (const nil {:Class :Module}) :new ...) ...)
+          (block (send (const nil? {:Class :Module}) :new ...) ...)
         PATTERN
 
         def_node_matcher :rspec_block?,

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -23,7 +23,7 @@ module RuboCop
       class EmptyLineAfterFinalLet < Cop
         MSG = 'Add an empty line after the last `let` block.'.freeze
 
-        def_node_matcher :let?, '(block $(send nil {:let :let!} ...) args ...)'
+        def_node_matcher :let?, '(block $(send nil? {:let :let!} ...) args ...)'
 
         def on_block(node)
           return unless let?(node) && !in_spec_block?(node)

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -17,7 +17,7 @@ module RuboCop
       class EmptyLineAfterSubject < Cop
         MSG = 'Add empty line after `subject`.'.freeze
 
-        def_node_matcher :subject?, '(block $(send nil :subject ...) args ...)'
+        def_node_matcher :subject?, '(block $(send nil? :subject ...) args ...)'
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -25,7 +25,7 @@ module RuboCop
         HOOKS = Hooks::ALL.node_pattern_union.freeze
 
         def_node_matcher :hook, <<-PATTERN
-          (block (send _ $#{HOOKS} ...) _ $!nil)
+          (block (send _ $#{HOOKS} ...) _ $!nil?)
         PATTERN
 
         def_node_search :expect, <<-PATTERN

--- a/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
@@ -31,11 +31,11 @@ module RuboCop
           MSG = 'Use a block to set a dynamic value to an attribute.'.freeze
 
           def_node_matcher :dynamic_defined_statically?, <<-PATTERN
-          (send nil _ (send ... ))
+          (send nil? _ (send ... ))
           PATTERN
 
           def_node_search :factory_attributes, <<-PATTERN
-          (block (send nil {:factory :trait} ...) _ { (begin $...) $(send ...) } )
+          (block (send nil? {:factory :trait} ...) _ { (begin $...) $(send ...) } )
           PATTERN
 
           def on_block(node)

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -36,8 +36,8 @@ module RuboCop
         FOCUS_TRUE   = s(:pair, FOCUS_SYMBOL, s(:true))
 
         def_node_matcher :metadata, <<-PATTERN
-          {(send nil #{FOCUSABLE_SELECTORS} ... (hash $...))
-           (send nil #{FOCUSABLE_SELECTORS} $...)}
+          {(send nil? #{FOCUSABLE_SELECTORS} ... (hash $...))
+           (send nil? #{FOCUSABLE_SELECTORS} $...)}
         PATTERN
 
         def_node_matcher :focused_block?, focused.send_pattern

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -31,8 +31,8 @@ module RuboCop
 
         def_node_matcher :implicit_expect, <<-PATTERN
           {
-            (send nil ${:should :should_not} ...)
-            (send (send nil $:is_expected) {:to :to_not :not_to} ...)
+            (send nil? ${:should :should_not} ...)
+            (send (send nil? $:is_expected) {:to :to_not :not_to} ...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -24,20 +24,20 @@ module RuboCop
 
         EXAMPLES = Examples::ALL.node_pattern_union.freeze
 
-        def_node_matcher :example?, "(block $(send nil #{EXAMPLES}) ...)"
+        def_node_matcher :example?, "(block $(send nil? #{EXAMPLES}) ...)"
 
         def_node_search :null_double, <<-PATTERN
           (lvasgn $_
             (send
-              $(send nil :instance_double
+              $(send nil? :instance_double
                 ...) :as_null_object))
         PATTERN
 
         def_node_search :have_received_usage, <<-PATTERN
           (send
-            (send nil :expect
+            (send nil? :expect
             (lvar $_)) :to
-            (send nil :have_received
+            (send nil? :have_received
             ...)
           ...)
         PATTERN

--- a/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
@@ -17,7 +17,7 @@ module RuboCop
         MSG = 'Omit `?` from `%<matcher>s`.'.freeze
 
         def_node_matcher :invalid_predicate_matcher?, <<-PATTERN
-          (send (send nil :expect ...) {:to :not_to :to_not} $(send nil #predicate?))
+          (send (send nil? :expect ...) {:to :not_to :to_not} $(send nil? #predicate?))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -26,7 +26,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :expectation?, <<-PATTERN
-          (send (send nil :expect (lvar %)) :to ...)
+          (send (send nil? :expect (lvar %)) :to ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -29,7 +29,7 @@ module RuboCop
       class LeadingSubject < Cop
         MSG = 'Declare `subject` above any other `let` declarations.'.freeze
 
-        def_node_matcher :subject?, '(block $(send nil :subject ...) args ...)'
+        def_node_matcher :subject?, '(block $(send nil? :subject ...) args ...)'
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -33,7 +33,7 @@ module RuboCop
       class LetBeforeExamples < Cop
         MSG = 'Move `let` before the examples in the group.'.freeze
 
-        def_node_matcher :let?, '(block (send nil {:let :let!} ...) ...)'
+        def_node_matcher :let?, '(block (send nil? {:let :let!} ...) ...)'
         def_node_matcher :example_or_group?, <<-PATTERN
           {
             #{(Examples::ALL + ExampleGroups::ALL).block_pattern}

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -30,9 +30,11 @@ module RuboCop
 
         MSG = 'Do not use `let!` for test setup.'.freeze
 
-        def_node_search :let_bang, '(block $(send nil :let! (sym $_)) args ...)'
+        def_node_search :let_bang, <<-PATTERN
+          (block $(send nil? :let! (sym $_)) args ...)
+        PATTERN
 
-        def_node_search :method_called?, '(send nil %)'
+        def_node_search :method_called?, '(send nil? %)'
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -32,10 +32,10 @@ module RuboCop
         SUPPORTED_STYLES = %w[allow expect].freeze
 
         def_node_matcher :message_expectation, <<-PATTERN
-          (send $(send nil {:expect :allow} ...) :to #receive_message?)
+          (send $(send nil? {:expect :allow} ...) :to #receive_message?)
         PATTERN
 
-        def_node_search :receive_message?, '(send nil :receive ...)'
+        def_node_search :receive_message?, '(send nil? :receive ...)'
 
         def on_send(node)
           message_expectation(node) do |match|

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -37,11 +37,11 @@ module RuboCop
         SUPPORTED_STYLES = %w[have_received receive].freeze
 
         def_node_matcher :message_expectation, %(
-          (send (send nil :expect $_) {:to :to_not :not_to} ...)
+          (send (send nil? :expect $_) {:to :to_not :not_to} ...)
         )
 
         def_node_search :receive_message, %(
-          $(send nil {:receive :have_received} ...)
+          $(send nil? {:receive :have_received} ...)
         )
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -37,7 +37,7 @@ module RuboCop
         MSG = 'Do not set more than one subject per example group'.freeze
 
         def_node_matcher :named_subject?, <<-PATTERN
-          (block (send nil :subject $sym) args ...)
+          (block (send nil? :subject $sym) args ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -48,7 +48,7 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :unnamed_subject, '$(send nil :subject)'
+        def_node_matcher :unnamed_subject, '$(send nil? :subject)'
 
         def on_block(node)
           return unless rspec_block?(node)

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -25,7 +25,7 @@ module RuboCop
         MSG = '`%<name>s` is already defined.'.freeze
 
         def_node_matcher :setup?, <<-PATTERN
-          (block (send nil {:let :let! :subject} (sym $_)) ...)
+          (block (send nil? {:let :let! :subject} (sym $_)) ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -18,19 +18,19 @@ module RuboCop
 
         def_node_matcher :predicate_in_actual?, <<-PATTERN
           (send
-            (send nil :expect {
-              (block $(send !nil #predicate? ...) ...)
-              $(send !nil #predicate? ...)})
+            (send nil? :expect {
+              (block $(send !nil? #predicate? ...) ...)
+              $(send !nil? #predicate? ...)})
             ${:to :not_to :to_not}
             $#boolean_matcher?)
         PATTERN
 
         def_node_matcher :be_bool?, <<-PATTERN
-          (send nil {:be :eq :eql :equal} {true false})
+          (send nil? {:be :eq :eql :equal} {true false})
         PATTERN
 
         def_node_matcher :be_boolthy?, <<-PATTERN
-          (send nil {:be_truthy :be_falsey :be_falsy :a_truthy_value :a_falsey_value :a_falsy_value})
+          (send nil? {:be_truthy :be_falsey :be_falsy :a_truthy_value :a_falsey_value :a_falsy_value})
         PATTERN
 
         def boolean_matcher?(node)
@@ -145,18 +145,18 @@ module RuboCop
 
         def_node_matcher :predicate_matcher?, <<-PATTERN
           (send
-            (send nil :expect $!nil)
+            (send nil? :expect $!nil?)
             {:to :not_to :to_not}
-            {$(send nil #predicate_matcher_name? ...)
-              (block $(send nil #predicate_matcher_name? ...) ...)})
+            {$(send nil? #predicate_matcher_name? ...)
+              (block $(send nil? #predicate_matcher_name? ...) ...)})
         PATTERN
 
         def_node_matcher :predicate_matcher_block?, <<-PATTERN
           (block
             (send
-              (send nil :expect $!nil)
+              (send nil? :expect $!nil?)
               {:to :not_to :to_not}
-              $(send nil #predicate_matcher_name?))
+              $(send nil? #predicate_matcher_name?))
             ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -41,7 +41,7 @@ module RuboCop
 
         def_node_matcher :and_return_value, <<-PATTERN
             (send
-              (send nil :receive (...)) :and_return $(...)
+              (send nil? :receive (...)) :and_return $(...)
             )
         PATTERN
 

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -29,7 +29,7 @@ module RuboCop
       class ScatteredLet < Cop
         MSG = 'Group all let/let! blocks in the example group together.'.freeze
 
-        def_node_matcher :let?, '(block (send nil {:let :let!} ...) ...)'
+        def_node_matcher :let?, '(block (send nil? {:let :let!} ...) ...)'
 
         def on_block(node)
           return unless example_group_with_body?(node)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -40,8 +40,8 @@ module RuboCop
         #   @yield [Symbol] subject name
         def_node_matcher :subject, <<-PATTERN
           {
-            (block (send nil :subject (sym $_)) args ...)
-            (block (send nil $:subject) args ...)
+            (block (send nil? :subject (sym $_)) args ...)
+            (block (send nil? $:subject) args ...)
           }
         PATTERN
 
@@ -57,12 +57,12 @@ module RuboCop
         #     expect(foo).to receive(:bar).with(1).and_return(2)
         def_node_matcher :message_expectation?, <<-PATTERN
           {
-            (send nil :allow (send nil %))
-            (send (send nil :expect (send nil %)) :to #receive_message?)
+            (send nil? :allow (send nil? %))
+            (send (send nil? :expect (send nil? %)) :to #receive_message?)
           }
         PATTERN
 
-        def_node_search :receive_message?, '(send nil :receive ...)'
+        def_node_search :receive_message?, '(send nil? :receive ...)'
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Prefer using verifying doubles over normal doubles.'.freeze
 
         def_node_matcher :unverified_double, <<-PATTERN
-          {(send nil {:double :spy} $_ ...) }
+          {(send nil? {:double :spy} $_ ...) }
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -16,7 +16,7 @@ module RuboCop
               'Chain the methods or remove it.'.freeze
 
         def_node_matcher :expect?, <<-PATTERN
-          (send nil :expect ...)
+          (send nil? :expect ...)
         PATTERN
 
         def_node_matcher :expect_block?, <<-PATTERN

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       #   Detect if node is `before`, `after`, `around`
       def_node_matcher :hook, <<-PATTERN
-        (block {$(send nil #{Hooks::ALL.node_pattern_union} ...)} ...)
+        (block {$(send nil? #{Hooks::ALL.node_pattern_union} ...)} ...)
       PATTERN
 
       def_node_matcher :subject, Subject::ALL.block_pattern

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -10,7 +10,7 @@ module RuboCop
         def_node_matcher :example_group?, ExampleGroups::ALL.block_pattern
 
         def_node_matcher :example_group_with_body?, <<-PATTERN
-          (block #{ExampleGroups::ALL.send_pattern} args [!nil])
+          (block #{ExampleGroups::ALL.send_pattern} args [!nil?])
         PATTERN
 
         def_node_matcher :example?, Examples::ALL.block_pattern


### PR DESCRIPTION
In https://github.com/bbatsov/rubocop/pull/4815 , NodePattern is changed.
This pull-request follows the change.

Sorry for the braking change. Please merge this pull-request after RuboCop v0.50.1 (or something) is released.