### PR TITLE
Fix false positive in RSpec/Focus cop. Fixes #398

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix false positive in `RSpec/Focus` cop. ([@Darhazer][])
+
 ## 1.18.0 (2017-09-29)
 
 * Fix false positive in `Capybara/FeatureMethods`. ([@Darhazer][])

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -40,9 +40,9 @@ module RuboCop
            (send nil #{FOCUSABLE_SELECTORS} $...)}
         PATTERN
 
-        def_node_matcher :focused_block?, focused.send_pattern
+        def_node_matcher :focused_block?, focused.block_pattern
 
-        def on_send(node)
+        def on_block(node)
           focus_metadata(node) do |focus|
             add_offense(focus, :expression)
           end
@@ -51,9 +51,10 @@ module RuboCop
         private
 
         def focus_metadata(node, &block)
-          yield(node) if focused_block?(node)
+          example_node, = *node
+          yield(example_node) if focused_block?(node)
 
-          metadata(node) do |matches|
+          metadata(example_node) do |matches|
             matches.grep(FOCUS_SYMBOL, &block)
             matches.grep(FOCUS_TRUE, &block)
           end

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
     RUBY
   end
 
+  it 'ignores variables with look like focuesed method' do
+    expect_no_offenses(<<-RUBY)
+      describe 'fit' do
+        let(:fit_attributes) { fit.id }
+        it 'is not focused' do
+          expect(fit.bar).to eq baz
+        end
+      end
+    RUBY
+  end
+
   it 'flags focused block types' do
     expect_offense(<<-RUBY)
       fdescribe 'test' do; end


### PR DESCRIPTION
Since the cop was checking `send` and not `block` pattern, it was giving offences when a message to a variable called fit, fdescribe or similar was sent