### PR TITLE
Bump minimum rubocop to 0.51.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ require 'bundler/gem_tasks'
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts 'Run `bundle install` to install missing gems'
+  warn e.message
+  warn 'Run `bundle install` to install missing gems'
   exit e.status_code
 end
 

--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def investigate(_)
           token_aligner.offending_tokens.each do |let|
-            add_offense(let, :begin)
+            add_offense(let, location: :begin)
           end
         end
 

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def investigate(_)
           token_aligner.offending_tokens.each do |let|
-            add_offense(let, :end)
+            add_offense(let, location: :end)
           end
         end
 

--- a/lib/rubocop/cop/rspec/any_instance.rb
+++ b/lib/rubocop/cop/rspec/any_instance.rb
@@ -29,7 +29,11 @@ module RuboCop
 
         def on_send(node)
           disallowed_stub(node) do |method|
-            add_offense(node, :expression, format(MSG, method: method))
+            add_offense(
+              node,
+              location: :expression,
+              message: format(MSG, method: method)
+            )
           end
         end
       end

--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -49,7 +49,7 @@ module RuboCop
         private
 
         def add_no_arg_offense(node)
-          add_offense(node, :expression, MSG_NO_ARG)
+          add_offense(node, location: :expression, message: MSG_NO_ARG)
         end
 
         def check_for_unused_proxy(block, proxy)
@@ -59,7 +59,11 @@ module RuboCop
             return if usage.include?(s(:lvar, name))
           end
 
-          add_offense(proxy, :expression, format(MSG_UNUSED_ARG, arg: name))
+          add_offense(
+            proxy,
+            location: :expression,
+            message: format(MSG_UNUSED_ARG, arg: name)
+          )
         end
       end
     end

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -41,7 +41,9 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          eql_type_with_identity(node) { |eql| add_offense(eql, :selector) }
+          eql_type_with_identity(node) do |eql|
+            add_offense(eql, location: :selector)
+          end
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -35,7 +35,11 @@ module RuboCop
 
         def on_send(node)
           before_or_after_all(node) do |hook|
-            add_offense(node, :expression, format(MSG, hook: hook.source))
+            add_offense(
+              node,
+              location: :expression,
+              message: format(MSG, hook: hook.source)
+            )
           end
         end
       end

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -32,7 +32,7 @@ module RuboCop
 
           def on_send(node)
             expectation_set_on_current_path(node) do
-              add_offense(node, :selector)
+              add_offense(node, location: :selector)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -53,7 +53,11 @@ module RuboCop
 
           def on_block(node)
             feature_method(node) do |send_node, match|
-              add_offense(send_node, :selector, format(MSG, MAP[match], match))
+              add_offense(
+                send_node,
+                location: :selector,
+                message: format(MSG, MAP[match], match)
+              )
             end
           end
 

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -51,7 +51,7 @@ module RuboCop
             return if pairs.any?(&method(:rails_metadata?))
           end
 
-          add_offense(args.first, :expression)
+          add_offense(args.first, location: :expression)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -29,7 +29,7 @@ module RuboCop
           return unless second_arg && second_arg.str_type?
           return if METHOD_STRING_MATCHER =~ one(second_arg.children)
 
-          add_offense(second_arg, :expression)
+          add_offense(second_arg, location: :expression)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -25,7 +25,9 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          describe_symbol?(node) { |match| add_offense(match, :expression) }
+          describe_symbol?(node) do |match|
+            add_offense(match, location: :expression)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -57,7 +57,11 @@ module RuboCop
           @described_class = described_class
 
           find_usage(body) do |match|
-            add_offense(match, :expression, message(match.const_name))
+            add_offense(
+              match,
+              location: :expression,
+              message: message(match.const_name)
+            )
           end
         end
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -70,7 +70,7 @@ module RuboCop
         def on_block(node)
           return unless example_group?(node) && !contains_example?(node)
 
-          add_offense(node.children.first, :expression)
+          add_offense(node.children.first, location: :expression)
         end
 
         private

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -34,7 +34,7 @@ module RuboCop
           return if latest_let.equal?(node.body.children.last)
 
           no_new_line_after(latest_let) do
-            add_offense(latest_let, :expression)
+            add_offense(latest_let, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -27,7 +27,7 @@ module RuboCop
           next_line = processed_source[send_line]
           return if next_line.blank?
 
-          add_offense(node, :expression, MSG)
+          add_offense(node, location: :expression, message: MSG)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -37,7 +37,7 @@ module RuboCop
 
           return unless length > max_length
 
-          add_offense(node, :expression, message(length))
+          add_offense(node, location: :expression, message: message(length))
         end
 
         private

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -67,7 +67,7 @@ module RuboCop
               expr.end_pos - 1
             )
 
-          add_offense(docstring, docstring, message)
+          add_offense(docstring, location: docstring, message: message)
         end
 
         def replacement_text(range)

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         def on_send(node)
           expect_literal(node) do |argument|
-            add_offense(argument, :expression)
+            add_offense(argument, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -39,8 +39,8 @@ module RuboCop
           hook(node) do |hook_name, body|
             expect(body) do |expect|
               method = send_node(expect)
-              add_offense(method, :selector,
-                          message(method, hook_name))
+              add_offense(method, location: :selector,
+                                  message: message(method, hook_name))
             end
           end
         end

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -27,7 +27,7 @@ module RuboCop
           name = variable_name[1..-1]
           return unless name.eql?('stdout') || name.eql?('stderr')
 
-          add_offense(node, :name, format(MSG, name: name))
+          add_offense(node, location: :name, message: format(MSG, name: name))
         end
 
         private

--- a/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_girl/dynamic_attribute_defined_statically.rb
@@ -42,7 +42,7 @@ module RuboCop
             return if node.method_name == :trait
             factory_attributes(node).to_a.flatten.each do |attribute|
               if dynamic_defined_statically?(attribute)
-                add_offense(attribute, :expression)
+                add_offense(attribute, location: :expression)
               end
             end
           end

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -57,7 +57,7 @@ module RuboCop
 
           return if filename_ends_with?(glob)
 
-          add_offense(node, :expression, format(MSG, glob))
+          add_offense(node, location: :expression, message: format(MSG, glob))
         end
 
         private

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def on_send(node)
           focus_metadata(node) do |focus|
-            add_offense(focus, :expression)
+            add_offense(focus, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -77,7 +77,11 @@ module RuboCop
             return check_implicit(method_send) unless scope_name
 
             style_detected(scope_name)
-            add_offense(method_send, :expression, explicit_message(scope_name))
+            add_offense(
+              method_send,
+              location: :expression,
+              message: explicit_message(scope_name)
+            )
           end
         end
 
@@ -95,7 +99,11 @@ module RuboCop
           style_detected(:implicit)
           return if implicit_style?
 
-          add_offense(method_send, :selector, format(EXPLICIT_MSG, style))
+          add_offense(
+            method_send,
+            location: :selector,
+            message: format(EXPLICIT_MSG, style)
+          )
         end
 
         def explicit_message(scope)

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         ENFORCED_REPLACEMENTS = alternatives.merge(alternatives.invert).freeze
 
-        def on_send(node)
+        def on_send(node) # rubocop:disable Metrics/MethodLength
           return unless (source_range = offending_expect(node))
 
           expectation_source = source_range.source
@@ -54,7 +54,11 @@ module RuboCop
           else
             opposite_style_detected
 
-            add_offense(node, source_range, offense_message(expectation_source))
+            add_offense(
+              node,
+              location: source_range,
+              message: offense_message(expectation_source)
+            )
           end
         end
 

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -47,7 +47,7 @@ module RuboCop
 
           null_double(node) do |var, receiver|
             have_received_usage(node) do |expected|
-              add_offense(receiver, :expression) if expected == var
+              add_offense(receiver, location: :expression) if expected == var
             end
           end
         end

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -63,7 +63,7 @@ module RuboCop
           ivar_usage(node) do |ivar, name|
             return if assignment_only? && !ivar_assigned?(node, name)
 
-            add_offense(ivar, :expression)
+            add_offense(ivar, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           invalid_predicate_matcher?(node) do |predicate|
-            add_offense(predicate, :expression)
+            add_offense(predicate, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def on_send(node)
           example_inclusion_offense(node, alternative_style) do
-            add_offense(node, :expression)
+            add_offense(node, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -32,7 +32,7 @@ module RuboCop
         def on_block(node)
           each?(node) do |arg, body|
             if single_expectation?(body, arg) || only_expectations?(body, arg)
-              add_offense(node.children.first, :expression)
+              add_offense(node.children.first, location: :expression)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -37,7 +37,7 @@ module RuboCop
           node.parent.each_child_node do |sibling|
             break if sibling.equal?(node)
 
-            break add_offense(node, :expression) if let?(sibling)
+            break add_offense(node, location: :expression) if let?(sibling)
           end
         end
 

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -58,7 +58,7 @@ module RuboCop
 
           node.each_child_node do |child|
             if let?(child)
-              add_offense(child, :expression) if example_found
+              add_offense(child, location: :expression) if example_found
             elsif example_or_group?(child)
               example_found = true
             end

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -40,7 +40,7 @@ module RuboCop
           return unless example_group?(node)
 
           unused_let_bang(node) do |let|
-            add_offense(let, :expression)
+            add_offense(let, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -17,7 +17,7 @@ module RuboCop
         def_node_matcher :message_chain, Matchers::MESSAGE_CHAIN.send_pattern
 
         def on_send(node)
-          message_chain(node) { add_offense(node, :selector) }
+          message_chain(node) { add_offense(node, location: :selector) }
         end
 
         def message(node)

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -41,7 +41,7 @@ module RuboCop
           message_expectation(node) do |match|
             return correct_style_detected if preferred_style?(match)
 
-            add_offense(match, :selector, MSG % style) do
+            add_offense(match, location: :selector, message: MSG % style) do
               opposite_style_detected
             end
           end

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -48,9 +48,11 @@ module RuboCop
           receive_message_matcher(node) do |receiver, message_matcher|
             return correct_style_detected if preferred_style?(message_matcher)
 
-            add_offense(message_matcher, :selector, error_message(receiver)) do
-              opposite_style_detected
-            end
+            add_offense(
+              message_matcher,
+              location: :selector,
+              message: error_message(receiver)
+            ) { opposite_style_detected }
           end
         end
 

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -32,7 +32,7 @@ module RuboCop
           return if single_top_level_describe?
           return unless top_level_nodes.first.equal?(node)
 
-          add_offense(node, :expression)
+          add_offense(node, location: :expression)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -99,8 +99,12 @@ module RuboCop
 
           add_offense(
             method,
-            :expression,
-            format(MSG, total: expectation_count, max: max_expectations)
+            location: :expression,
+            message: format(
+              MSG,
+              total: expectation_count,
+              max: max_expectations
+            )
           )
         end
 

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -46,7 +46,7 @@ module RuboCop
           subjects = RuboCop::RSpec::ExampleGroup.new(node).subjects
 
           subjects[0...-1].each do |subject|
-            add_offense(subject, :expression)
+            add_offense(subject, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -54,7 +54,7 @@ module RuboCop
           return unless rspec_block?(node)
 
           subject_usage(node) do |subject_node|
-            add_offense(subject_node, :selector)
+            add_offense(subject_node, location: :selector)
           end
         end
 

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -99,7 +99,11 @@ module RuboCop
 
         def on_top_level_describe(node, _)
           find_nested_contexts(node.parent) do |context, nesting|
-            add_offense(context.children.first, :expression, message(nesting))
+            add_offense(
+              context.children.first,
+              location: :expression,
+              message: message(nesting)
+            )
           end
         end
 

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           not_to_not_offense(node, alternative_style) do
-            add_offense(node, :expression)
+            add_offense(node, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -34,7 +34,11 @@ module RuboCop
           _describe, _args, body = *node
 
           find_duplicates(body) do |duplicate, name|
-            add_offense(duplicate, :expression, format(MSG, name: name))
+            add_offense(
+              duplicate,
+              location: :expression,
+              message: format(MSG, name: name)
+            )
           end
         end
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -12,7 +12,11 @@ module RuboCop
 
         def check_inflected(node)
           predicate_in_actual?(node) do |predicate|
-            add_offense(node, node.loc.expression, message_inflected(predicate))
+            add_offense(
+              node,
+              location: :expression,
+              message: message_inflected(predicate)
+            )
           end
         end
 
@@ -130,16 +134,24 @@ module RuboCop
 
         private
 
-        def check_explicit(node)
+        def check_explicit(node) # rubocop:disable Metrics/MethodLength
           predicate_matcher_block?(node) do |_actual, matcher|
-            add_offense(node, :expression, message_explicit(matcher))
+            add_offense(
+              node,
+              location: :expression,
+              message: message_explicit(matcher)
+            )
             ignore_node(node.children.first)
             return
           end
 
           return if part_of_ignored_node?(node)
           predicate_matcher?(node) do |_actual, matcher|
-            add_offense(node, :expression, message_explicit(matcher))
+            add_offense(
+              node,
+              location: :expression,
+              message: message_explicit(matcher)
+            )
           end
         end
 

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -34,7 +34,7 @@ module RuboCop
           return unless example_group?(node)
 
           repeated_descriptions(node).each do |repeated_description|
-            add_offense(repeated_description, :expression)
+            add_offense(repeated_description, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/repeated_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_example.rb
@@ -20,7 +20,7 @@ module RuboCop
           return unless example_group?(node)
 
           repeated_examples(node).each do |repeated_example|
-            add_offense(repeated_example, :expression)
+            add_offense(repeated_example, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -57,7 +57,13 @@ module RuboCop
 
         def check_and_return_call(node)
           and_return_value(node) do |args|
-            add_offense(node, :expression, MSG_BLOCK) unless dynamic?(args)
+            unless dynamic?(args)
+              add_offense(
+                node,
+                location: :expression,
+                message: MSG_BLOCK
+              )
+            end
           end
         end
 
@@ -66,7 +72,13 @@ module RuboCop
           return unless block
 
           _receiver, _args, body = *block
-          add_offense(node, :expression, MSG_AND_RETURN) unless dynamic?(body)
+          unless dynamic?(body) # rubocop:disable Style/GuardClause
+            add_offense(
+              node,
+              location: :expression,
+              message: MSG_AND_RETURN
+            )
+          end
         end
 
         def dynamic?(node)

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -45,7 +45,7 @@ module RuboCop
 
           node.each_child_node do |child|
             if let?(child)
-              add_offense(child, :expression) if mix_found
+              add_offense(child, location: :expression) if mix_found
               let_found = true
             elsif let_found
               mix_found = true

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -29,7 +29,7 @@ module RuboCop
           return unless example_group?(node)
 
           analyzable_hooks(node).each do |repeated_hook|
-            add_offense(repeated_hook, :expression)
+            add_offense(repeated_hook, location: :expression)
           end
         end
 

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -99,7 +99,11 @@ module RuboCop
         end
 
         def add_shared_item_offense(node, message)
-          add_offense(node.children.first, :expression, message)
+          add_offense(
+            node.children.first,
+            location: :expression,
+            message: message
+          )
         end
       end
     end

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -30,7 +30,7 @@ module RuboCop
 
             return if arg.hash_type? && !single_key_hash?(arg)
 
-            add_offense(node, :selector)
+            add_offense(node, location: :selector)
           end
         end
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -67,7 +67,9 @@ module RuboCop
         def on_block(node)
           return unless example_group?(node)
 
-          find_subject_stub(node) { |stub| add_offense(stub, :expression) }
+          find_subject_stub(node) do |stub|
+            add_offense(stub, location: :expression)
+          end
         end
 
         private

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -28,7 +28,7 @@ module RuboCop
           unverified_double(node) do |name|
             return if name.sym_type? && cop_config['IgnoreSymbolicNames']
 
-            add_offense(node, :expression)
+            add_offense(node, location: :expression)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         def check_expect(node)
           return unless void?(node)
-          add_offense(node, :expression)
+          add_offense(node, location: :expression)
         end
 
         def void?(expect)

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.18.0'.freeze
+      STRING = '1.19.0'.freeze
     end
   end
 end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.50.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.51.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
       end
 
       def on_send(node)
-        add_offense(node, :expression, 'I flag everything')
+        add_offense(node, location: :expression, message: 'I flag everything')
       end
     end
     RuboCop::RSpec::FakeCop


### PR DESCRIPTION
 - Fix new offenses
 - Update to new `add_offense` interface
 - Bump version to 1.19.0