### PR TITLE
Fix to avoid return_from_stub error on empty block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix exception in `RSpec/ReturnFromStub` on empty block. ([@yevhene][])
+
 ## 1.19.0 (2017-10-18)
 
 Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
@@ -259,3 +261,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@bmorrall]: https:/github.com/bmorrall
 [@zverok]: https:/github.com/zverok
 [@timrogers]: https://github.com/timrogers
+[@yevhene]: https://github.com/yevhene

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -72,7 +72,7 @@ module RuboCop
           return unless block
 
           _receiver, _args, body = *block
-          unless dynamic?(body) # rubocop:disable Style/GuardClause
+          unless body && dynamic?(body) # rubocop:disable Style/GuardClause
             add_offense(
               node,
               location: :expression,

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
       RUBY
     end
 
+    it 'finds empty values returned from block' do
+      expect_offense(<<-RUBY)
+        it do
+          allow(Foo).to receive(:bar) {}
+                        ^^^^^^^^^^^^^ Use `and_return` for static values.
+        end
+      RUBY
+    end
+
     it 'finds array with only static values returned from block' do
       expect_offense(<<-RUBY)
         it do


### PR DESCRIPTION
I have a bunch of legacy code and guys use empty blocks, like:
```
before { allow(MyModule).to receive(:perform_async) {} }
```
And rubocop-rspec fails with:
```
undefined method `recursive_literal?' for nil:NilClass
/home/yevhene/.rvm/gems/ruby-2.4.1/gems/rubocop-rspec-1.19.0/lib/rubocop/cop/rspec/return_from_stub.r
b:85:in `dynamic?'
...
```
When I try to `--auto-gen-config`.
I decided to treat empty block like a static value, but I think separate cop should check this behavior in future.