### PR TITLE
Implement autocorrect for ReturnFromStub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `RSpec/ExpectChange` cop to enforce consistent usage of the change matcher. ([@Darhazer][])
 * Add autocorrect support to `RSpec/LetBeforeExamples`. ([@Darhazer][])
 * Fix `RSpec/InstanceVariable` flagging instance variables inside dynamically defined class. ([@Darhazer][])
+* Add autocorrect support for `RSpec/ReturnFromStub` cop. ([@bquorning][])
 
 ## 1.21.0 (2017-12-13)
 

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -115,6 +115,31 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
         end
       RUBY
     end
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar) { 42 }',
+                     'allow(Foo).to receive(:bar).and_return(42)'
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar) { { foo: 42 } }',
+                     'allow(Foo).to receive(:bar).and_return({ foo: 42 })'
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar) {}',
+                     'allow(Foo).to receive(:bar).and_return(nil)'
+
+    original = <<-RUBY
+      allow(Foo).to receive(:bar) do
+        'You called ' \\
+        'me'
+      end
+    RUBY
+    corrected = <<-RUBY
+      allow(Foo).to receive(:bar).and_return('You called ' \\
+        'me')
+    RUBY
+
+    include_examples 'autocorrect', original, corrected
   end
 
   context 'with EnforcedStyle `block`' do
@@ -153,5 +178,45 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
         end
       RUBY
     end
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).and_return(42)',
+                     'allow(Foo).to receive(:bar) { 42 }'
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).and_return({ foo: 42 })',
+                     'allow(Foo).to receive(:bar) { { foo: 42 } }'
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).and_return(foo: 42)',
+                     'allow(Foo).to receive(:bar) { { foo: 42 } }'
+
+    original = <<-RUBY
+      allow(Foo).to receive(:bar).and_return(
+        a: 42,
+        b: 43
+      )
+    RUBY
+    corrected = <<-RUBY # Not perfect, but good enough.
+      allow(Foo).to receive(:bar) { { a: 42,
+        b: 43 } }
+    RUBY
+
+    include_examples 'autocorrect', original, corrected
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).and_return(nil)',
+                     'allow(Foo).to receive(:bar) { nil }'
+
+    original = <<-RUBY
+      allow(Foo).to receive(:bar).and_return('You called ' \\
+        'me')
+    RUBY
+    corrected = <<-RUBY
+      allow(Foo).to receive(:bar) { 'You called ' \\
+        'me' }
+    RUBY
+
+    include_examples 'autocorrect', original, corrected
   end
 end


### PR DESCRIPTION
~So far just for the `and_return` config.~ Works for both `block` and `and_return` configurations. It does however not work for HEREDOCs.

@Darhazer I remember you were working on this in #422. I hacked this one autocorrector together today and it seems to work. Do you have some test cases lying around? You’re welcome to push to this branch if you want to contribute.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
