### PR TITLE
Fix `RSpec/SubjectStub` cop matches receive message inside all matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Rename namespace `FactoryGirl` to `FactoryBot` following original library update. ([@walf443][])
 * Fix exception in `RSpec/ReturnFromStub` on empty block. ([@yevhene][])
 * Add `RSpec/ContextWording` cop. ([@pirj][], [@telmofcosta][])
+* Fix `RSpec/SubjectStub` cop matches receive message inside all matcher. ([@walf443][])
 
 ## 1.19.0 (2017-10-18)
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -55,14 +55,25 @@ module RuboCop
         #     expect(foo).to receive(:bar)
         #     expect(foo).to receive(:bar).with(1)
         #     expect(foo).to receive(:bar).with(1).and_return(2)
+        #
+        #   @example source that not matches
+        #     expect(foo).to all(receive(:bar))
+        #
         def_node_matcher :message_expectation?, <<-PATTERN
           {
             (send nil? :allow (send nil? %))
-            (send (send nil? :expect (send nil? %)) :to #receive_message?)
+            (send (send nil? :expect (send nil? %)) :to #expectation?)
           }
         PATTERN
 
+        def_node_matcher :all_matcher?, '(send nil? :all ...)'
+
         def_node_search :receive_message?, '(send nil? :receive ...)'
+
+        def expectation?(node)
+          return if all_matcher?(node)
+          receive_message?(node)
+        end
 
         def on_block(node)
           return unless example_group?(node)

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
+  it 'ignores stub when inside all matcher' do
+    expect_no_offenses(<<-RUBY)
+      describe Foo do
+        subject(:foo) { [Object.new] }
+        it 'tries to trick rubocop-rspec' do
+          expect(foo).to all(receive(:baz))
+        end
+      end
+    RUBY
+  end
+
   it 'flags nested subject stubs when nested subject uses same name' do
     expect_offense(<<-RUBY)
       describe Foo do


### PR DESCRIPTION
Rebased version of #491.

Fixes #488.
Closes #491.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
