### PR TITLE
Let DescriptionExtractor ignore helper classes

### DIFF
--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -19,6 +19,7 @@ module RuboCop
 
       # Decorator of a YARD code object for working with documented rspec cops
       class CodeObject
+        COP_CLASS_NAMES = %w[RuboCop::Cop RuboCop::Cop::RSpec::Cop].freeze
         RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'.freeze
 
         def initialize(yardoc)
@@ -29,7 +30,10 @@ module RuboCop
         #
         # @return [Boolean]
         def rspec_cop?
-          class_documentation? && rspec_cop_namespace? && !abstract?
+          class_documentation? &&
+            rspec_cop_namespace? &&
+            cop_subclass? &&
+            !abstract?
         end
 
         # Configuration for the documented cop that would live in default.yml
@@ -59,6 +63,14 @@ module RuboCop
 
         def documented_constant
           yardoc.to_s
+        end
+
+        def cop_subclass?
+          # YARD superclass resolution is a bit flaky: All classes loaded before
+          # RuboCop::Cop::WorkaroundCop are shown as having RuboCop::Cop as
+          # superclass, while all the following classes are listed as having
+          # RuboCop::Cop::RSpec::Cop as their superclass.
+          COP_CLASS_NAMES.include?(yardoc.superclass.path)
         end
 
         def abstract?

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -20,13 +20,17 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
       # Some description
       #
       # @note only works with foo
-      class RuboCop::Cop::RSpec::Foo
+      class RuboCop::Cop::RSpec::Foo < RuboCop::Cop::RSpec::Cop
         # Hello
         def bar
         end
+
+        # :nodoc:
+        class HelperClassForFoo
+        end
       end
 
-      class RuboCop::Cop::RSpec::Undocumented
+      class RuboCop::Cop::RSpec::Undocumented < RuboCop::Cop::RSpec::Cop
         # Hello
         def bar
         end


### PR DESCRIPTION
In some cases, it is desirable to group some logic together in a "helper" class *inside* a cop. But the `DescriptionExtractor` would mis-identify these classes as RSpec cops and fail while trying to read their configuration from default.yml.

We can avoid this by only including classes that inherit from `RuboCop::Cop` or `RuboCop::Cop::RSpec::Cop`. The cops in this project (currently) always inherits from `RuboCop::Cop::RSpec::Cop`, but YARD superclass resolution is a bit flaky: All classes loaded before `RuboCop::Cop::WorkaroundCop` are shown as having `RuboCop::Cop` as superclass, while all the following classes are listed as having `RuboCop::Cop::RSpec::Cop` as their superclass.

Examples of where helper classes would be useful: #476, #495.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) is passing.
