### PR TITLE
Add “without” to default prefixes for ContextWording

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,13 +30,6 @@ Lint/InterpolationCheck:
   Exclude:
     - spec/**/*.rb
 
-RSpec/ContextWording:
-  Enabled: true
-  Prefixes:
-    - when
-    - with
-    - without
-
 RSpec/ExampleLength:
   Max: 19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add "without" to list of default allowed prefixes for `RSpec/ContextWording`. ([@bquorning][])
+
 ## 1.20.0 (2017-11-09)
 
 * Rename namespace `FactoryGirl` to `FactoryBot` following original library update. ([@walf443][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -49,6 +49,7 @@ RSpec/ContextWording:
   Prefixes:
   - when
   - with
+  - without
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 RSpec/DescribeClass:

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -8,11 +8,13 @@ module RuboCop
       # @see https://github.com/reachlocal/rspec-style-guide#context-descriptions
       # @see http://www.betterspecs.org/#contexts
       #
-      # @example `Prefixes` configuration option, defaults: 'when', and 'with'
+      # @example `Prefixes` configuration option, defaults: 'when', 'with', and
+      # 'without'
       #   Prefixes:
       #     - when
       #     - with
       #     - without
+      #     - if
       #
       # @example
       #   # bad

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -42,19 +42,19 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
   end
 
   context 'when configured' do
-    let(:cop_config) { { 'Prefixes' => %w[without] } }
+    let(:cop_config) { { 'Prefixes' => %w[if] } }
 
     it 'finds context without whitelisted prefixes at the beginning' do
       expect_offense(<<-RUBY)
         context 'when display name is present' do
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Start context description with 'without'.
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Start context description with 'if'.
         end
       RUBY
     end
 
     it 'skips descriptions with whitelisted prefixes at the beginning' do
       expect_no_offenses(<<-RUBY)
-        context 'without a display name' do
+        context 'if display name is present' do
         end
       RUBY
     end


### PR DESCRIPTION
Turned out that betterspecs.org does recommend also using “without” – they just didn’t update the website after https://github.com/lelylan/betterspecs/pull/157.

It makes me question whether betterspecs.org really does reflect community best practices… 🤔

Fixes #500.

cc @Drenmi, @pirj 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
