### PR TITLE
Improve performance when user does not override default RSpec Pattern config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Improve performance when user does not override default RSpec Pattern config. ([@walf443][])
+
 ## 1.20.1 (2017-11-15)
 
 * Add "without" to list of default allowed prefixes for `RSpec/ContextWording`. ([@bquorning][])


### PR DESCRIPTION
I noticed that RuboCop::Cop::RSpec::Cop#rspec_pattern is not so fast.
RSpec Pattern setting is not defined in most case, I think.
So change to cache building Regexp for default case.

Here is the stackprof result of running ./bin/rubocop at rubocop repositories on master

```
bundle exec stackprof tmp/stackprof-cpu-rubocop.dump
==================================
  Mode: cpu(1000)
  Samples: 52150 (0.02% miss rate)
  GC: 3229 (6.19%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      8039  (15.4%)        4264   (8.2%)     RuboCop::AST::Node#each_child_node
      3352   (6.4%)        3352   (6.4%)     block (2 levels) in <class:Node>
      3229   (6.2%)        3229   (6.2%)     (garbage collection)
      5362  (10.3%)        2846   (5.5%)     Parser::Lexer#advance
      2386   (4.6%)        2386   (4.6%)     AST::Node#to_a
      2133   (4.1%)        2133   (4.1%)     Parser::Source::Buffer#slice
      1421   (2.7%)        1061   (2.0%)     Parser::Source::Buffer#line_for_position
      1555   (3.0%)         908   (1.7%)     RuboCop::Cop::Cop#cop_config
       570   (1.1%)         570   (1.1%)     #<Module:0x00007f9dddefffb0>.of
       557   (1.1%)         557   (1.1%)     Parser::Source::Range#initialize
       620   (1.2%)         549   (1.1%)     RuboCop::Cop::RSpec::Cop#rspec_pattern
       651   (1.2%)         538   (1.0%)     RuboCop::ConfigStore#for
       479   (0.9%)         479   (0.9%)     RuboCop::Formatter::ProgressFormatter#report_file_as_mark
      1001   (1.9%)         440   (0.8%)     AST::Node#initialize
       592   (1.1%)         399   (0.8%)     RuboCop::Cop::Cop#cop_name
       429   (0.8%)         398   (0.8%)     RuboCop::Cop::VariableForce#scanned_node?
       561   (1.1%)         397   (0.8%)     Parser::AST::Node#assign_properties
       731   (1.4%)         396   (0.8%)     Parser::Source::Buffer#line_for
     18229  (35.0%)         360   (0.7%)     RuboCop::Cop::Commissioner#on_send
       340   (0.7%)         340   (0.7%)     Parser::Source::Buffer#line_begins
       709   (1.4%)         338   (0.6%)     Parser::Source::Buffer#column_for_position
       333   (0.6%)         333   (0.6%)     AST::Node#eql?
       332   (0.6%)         332   (0.6%)     Parser::Lexer::Literal#coerce_encoding
       324   (0.6%)         324   (0.6%)     RuboCop::Cop::Cop#initialize
       322   (0.6%)         322   (0.6%)     RuboCop::Cop::Cop.badge
       310   (0.6%)         310   (0.6%)     RuboCop::AST::Node#parent
       308   (0.6%)         308   (0.6%)     RuboCop::Cop::IgnoredNode#ignored_nodes
      1009   (1.9%)         304   (0.6%)     RuboCop::Config#for_cop
       282   (0.5%)         282   (0.5%)     RuboCop::AST::MethodDispatchNode#setter_method?
      2342   (4.5%)         282   (0.5%)     RuboCop::Cop::Commissioner#remove_irrelevant_cops
```

-----------------



Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
