### PR TITLE
Fix violation of Gemspec/RequiredRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.1
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
Rubocop master branch have a few new cops. This PR makes us comply with Gemspec/RequiredRubyVersion.

This is basically a change I forgot in #213.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
