### PR TITLE
Fix violations of Lint/MissingCopEnableDirective

### DIFF
--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
         add_offense(node, location: :expression, message: 'I flag everything')
       end
     end
+    # rubocop:enable ClassAndModuleChildren
     RuboCop::RSpec::FakeCop
   end
 

--- a/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
@@ -2,6 +2,8 @@
 
 # rubocop:disable Metrics/LineLength
 RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStatically do
+  # rubocop:enable Metrics/LineLength
+
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                  ^^^^^^ Focused spec found.
     RUBY
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'does not flag unfocused specs' do
     expect_no_offenses(<<-RUBY)


### PR DESCRIPTION
Rubocop master branch have a few new cops. This PR makes us comply with Lint/MissingCopEnableDirective.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
