### PR TITLE
Add AggregateFailuresByDefault configuration for RSpec/MultipleExpectations cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Improve performance when user does not override default RSpec Pattern config. ([@walf443][])
+* Add `AggregateFailuresByDefault` configuration for `RSpec/MultipleExpectations` cop. ([@onk][])
 
 ## 1.20.1 (2017-11-15)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -237,6 +237,7 @@ RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
   Enabled: true
   Max: 1
+  AggregateFailuresByDefault: false
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 RSpec/MultipleSubjects:

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -79,7 +79,8 @@ module RuboCop
         def example_with_aggregated_failures?(node)
           example = node.children.first
 
-          with_aggregated_failures?(example) &&
+          (aggregated_failures_by_default? ||
+            with_aggregated_failures?(example)) &&
             !disabled_aggregated_failures?(example)
         end
 
@@ -110,6 +111,10 @@ module RuboCop
 
         def max_expectations
           Integer(cop_config.fetch('Max', 1))
+        end
+
+        def aggregated_failures_by_default?
+          cop_config.fetch('AggregateFailuresByDefault', false)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
   end
 
-  context 'with configuration' do
+  context 'with Max configuration' do
     let(:cop_config) do
       { 'Max' => '2' }
     end
@@ -156,6 +156,57 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
             expect(qux).to eq(bar)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with AggregateFailuresByDefault configuration' do
+    let(:cop_config) do
+      { 'AggregateFailuresByDefault' => true }
+    end
+
+    it 'ignores examples without metadata' do
+      expect_no_offenses(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice' do
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores examples with `:aggregate_failures`' do
+      expect_no_offenses(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice', :aggregate_failures do
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores examples with `aggregate_failures: true`' do
+      expect_no_offenses(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice', aggregate_failures: true do
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
+          end
+        end
+      RUBY
+    end
+
+    it 'checks examples with `aggregate_failures: false`' do
+      expect_offense(<<-RUBY)
+        describe Foo do
+          it 'uses expect twice', aggregate_failures: false do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            expect(foo).to eq(bar)
+            expect(baz).to eq(bar)
           end
         end
       RUBY


### PR DESCRIPTION
Support cases that `aggregate_failures` metadata is set in spec_helper.
In that case, examples without metadata will not detect offence.

> If you want to enable this feature everywhere,
> you can use define_derived_metadata:
>
> ```
> RSpec.configure do |c|
>   c.define_derived_metadata do |meta|
>     meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
>   end
> end
> ```

see: http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/

Related Issues: #451 
With this option, It can detect offense when the example has `aggregate_failures: false` metadata.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
