### PR TITLE
Fix RuboCop v0.52.0 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,11 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
+
+# FIXME
+Style/FormatStringToken:
+  Enabled: false
+
+# Awaiting bugfix: https://github.com/bbatsov/rubocop/issues/5224
+Layout/EmptyLinesAroundArguments:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,10 +37,6 @@ RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
 
-# FIXME
-Style/FormatStringToken:
-  Enabled: false
-
 # Awaiting bugfix: https://github.com/bbatsov/rubocop/issues/5224
 Layout/EmptyLinesAroundArguments:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Compatibility with RuboCop v0.52.0. ([@bquorning][])
 * Improve performance when user does not override default RSpec Pattern config. ([@walf443][])
 * Add `AggregateFailuresByDefault` configuration for `RSpec/MultipleExpectations` cop. ([@onk][])
 

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -33,7 +33,7 @@ module RuboCop
         #     end
         #   end
         class FeatureMethods < Cop
-          MSG = 'Use `%s` instead of `%s`.'.freeze
+          MSG = 'Use `%<replacement>s` instead of `%<method>s`.'.freeze
 
           # https://git.io/v7Kwr
           MAP = {
@@ -56,7 +56,7 @@ module RuboCop
               add_offense(
                 send_node,
                 location: :selector,
-                message: format(MSG, MAP[match], match)
+                message: format(MSG, method: match, replacement: MAP[match])
               )
             end
           end

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -37,7 +37,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         DESCRIBED_CLASS = 'described_class'.freeze
-        MSG             = 'Use `%s` instead of `%s`.'.freeze
+        MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'.freeze
 
         def_node_matcher :common_instance_exec_closure?, <<-PATTERN
           (block (send (const nil? {:Class :Module}) :new ...) ...)
@@ -91,9 +91,10 @@ module RuboCop
 
         def message(offense)
           if style == :described_class
-            format(MSG, DESCRIBED_CLASS, offense)
+            format(MSG, replacement: DESCRIBED_CLASS, src: offense)
           else
-            format(MSG, @described_class.const_name, DESCRIBED_CLASS)
+            format(MSG, replacement: @described_class.const_name,
+                        src: DESCRIBED_CLASS)
           end
         end
 

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -28,7 +28,7 @@ module RuboCop
       class ExampleLength < Cop
         include CodeLength
 
-        MSG = 'Example has too many lines [%d/%d].'.freeze
+        MSG = 'Example has too many lines [%<total>d/%<max>d].'.freeze
 
         def on_block(node)
           return unless example?(node)
@@ -47,7 +47,7 @@ module RuboCop
         end
 
         def message(length)
-          format(MSG, length, max_length)
+          format(MSG, total: length, max: max_length)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -44,7 +44,7 @@ module RuboCop
       class FilePath < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Spec path should end with `%s`.'.freeze
+        MSG = 'Spec path should end with `%<suffix>s`.'.freeze
 
         def_node_search :const_described?,  '(send _ :describe (const ...) ...)'
         def_node_search :routing_metadata?, '(pair (sym :type) (sym :routing))'
@@ -57,7 +57,11 @@ module RuboCop
 
           return if filename_ends_with?(glob)
 
-          add_offense(node, location: :expression, message: format(MSG, glob))
+          add_offense(
+            node,
+            location: :expression,
+            message: format(MSG, suffix: glob)
+          )
         end
 
         private

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -60,8 +60,9 @@ module RuboCop
       class HookArgument < Cop
         include ConfigurableEnforcedStyle
 
-        IMPLICIT_MSG = 'Omit the default `%p` argument for RSpec hooks.'.freeze
-        EXPLICIT_MSG = 'Use `%p` for RSpec hooks.'.freeze
+        IMPLICIT_MSG = 'Omit the default `%<scope>p` ' \
+                       'argument for RSpec hooks.'.freeze
+        EXPLICIT_MSG = 'Use `%<scope>p` for RSpec hooks.'.freeze
 
         HOOKS = Hooks::ALL.node_pattern_union.freeze
 
@@ -102,15 +103,15 @@ module RuboCop
           add_offense(
             method_send,
             location: :selector,
-            message: format(EXPLICIT_MSG, style)
+            message: format(EXPLICIT_MSG, scope: style)
           )
         end
 
         def explicit_message(scope)
           if implicit_style?
-            format(IMPLICIT_MSG, scope)
+            format(IMPLICIT_MSG, scope: scope)
           else
-            format(EXPLICIT_MSG, style)
+            format(EXPLICIT_MSG, scope: style)
           end
         end
 

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -21,8 +21,8 @@ module RuboCop
       class ItBehavesLike < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%s` over `%s` when including examples in '\
-              'a nested context.'.freeze
+        MSG = 'Prefer `%<replacement>s` over `%<original>s` when including '\
+              'examples in a nested context.'.freeze
 
         def_node_matcher :example_inclusion_offense, '(send _ % ...)'
 
@@ -39,7 +39,7 @@ module RuboCop
         private
 
         def message(_node)
-          format(MSG, style, alternative_style)
+          format(MSG, replacement: style, original: alternative_style)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -63,8 +63,12 @@ module RuboCop
 
         def node_range(node)
           range = node.source_range
-          range = range_with_surrounding_space(range, :left, false)
-          range = range_with_surrounding_space(range, :right, true)
+          range = range_with_surrounding_space(
+            range: range, side: :left, newlines: false
+          )
+          range = range_with_surrounding_space(
+            range: range, side: :right, newlines: true
+          )
           range
         end
 

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -27,7 +27,7 @@ module RuboCop
       class MessageExpectation < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%s` for setting message expectations.'.freeze
+        MSG = 'Prefer `%<style>s` for setting message expectations.'.freeze
 
         SUPPORTED_STYLES = %w[allow expect].freeze
 
@@ -41,7 +41,8 @@ module RuboCop
           message_expectation(node) do |match|
             return correct_style_detected if preferred_style?(match)
 
-            add_offense(match, location: :selector, message: MSG % style) do
+            message = format(MSG, style: style)
+            add_offense(match, location: :selector, message: message) do
               opposite_style_detected
             end
           end

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -31,8 +31,8 @@ module RuboCop
                       'expectations.'.freeze
 
         MSG_HAVE_RECEIVED = 'Prefer `have_received` for setting message '\
-                            'expectations. Setup `%s` as a spy using `allow`'\
-                            ' or `instance_spy`.'.freeze
+                            'expectations. Setup `%<source>s` as a spy using '\
+                            '`allow` or `instance_spy`.'.freeze
 
         SUPPORTED_STYLES = %w[have_received receive].freeze
 
@@ -73,7 +73,7 @@ module RuboCop
           when :receive
             MSG_RECEIVE
           when :have_received
-            MSG_HAVE_RECEIVED % receiver.source
+            format(MSG_HAVE_RECEIVED, source: receiver.source)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -87,7 +87,8 @@ module RuboCop
       class NestedGroups < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Maximum example group nesting exceeded [%d/%d].'.freeze
+        MSG = 'Maximum example group nesting exceeded ' \
+              '[%<total>d/%<max>d].'.freeze
 
         DEPRECATED_MAX_KEY = 'MaxNesting'.freeze
 
@@ -120,7 +121,7 @@ module RuboCop
         end
 
         def message(nesting)
-          format(MSG, nesting, max_nesting)
+          format(MSG, total: nesting, max: max_nesting)
         end
 
         def max_nesting

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -16,7 +16,7 @@ module RuboCop
       class NotToNot < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%s` over `%s`.'.freeze
+        MSG = 'Prefer `%<replacement>s` over `%<original>s`.'.freeze
 
         def_node_matcher :not_to_not_offense, '(send _ % ...)'
 
@@ -33,7 +33,7 @@ module RuboCop
         private
 
         def message(_node)
-          format(MSG, style, alternative_style)
+          format(MSG, replacement: style, original: alternative_style)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -311,8 +311,6 @@ module RuboCop
           check_explicit(node) if style == :explicit
         end
 
-        private
-
         def autocorrect(node)
           case style
           when :inflected
@@ -321,6 +319,8 @@ module RuboCop
             autocorrect_explicit(node)
           end
         end
+
+        private
 
         # returns args location with whitespace
         # @example

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.51.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.52.0'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe RuboCop::RSpec::Example do
 
   it 'extracts doc string' do
     expect(example("it('does x') { foo }").doc_string)
-      .to eql(s(:str, 'does x'))
+      .to eq(s(:str, 'does x'))
   end
 
   it 'extracts doc string for unimplemented examples' do
     expect(example("it('does x')").doc_string)
-      .to eql(s(:str, 'does x'))
+      .to eq(s(:str, 'does x'))
   end
 
   it 'returns nil for examples without doc strings' do


### PR DESCRIPTION
RuboCop v0.52.0 has been released, and we were not completely compatible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.