### PR TITLE
Bump version to 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.21.0 (2017-12-13)
+
 * Compatibility with RuboCop v0.52.0. ([@bquorning][])
 * Improve performance when user does not override default RSpec Pattern config. ([@walf443][])
 * Add `AggregateFailuresByDefault` configuration for `RSpec/MultipleExpectations` cop. ([@onk][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.20.1'.freeze
+      STRING = '1.21.0'.freeze
     end
   end
 end


### PR DESCRIPTION
…to be compatible with the most recent RuboCop version.