### PR TITLE
Updates `describe_class` to account for RSpecs `:system` wrapper of t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Updates `describe_class` to account for RSpecs `:system` wrapper of rails system tests. ([@EliseFitz15][])
+
 ## 1.21.0 (2017-12-13)
 
 * Compatibility with RuboCop v0.52.0. ([@bquorning][])
@@ -280,3 +282,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@walf443]: https://github.com/walf443
 [@pirj]: https://github.com/pirj
 [@telmofcosta]: https://github.com/telmofcosta
+[@EliseFitz15]: https://github.com/EliseFitz15

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -36,7 +36,7 @@ module RuboCop
         def_node_matcher :rails_metadata?, <<-PATTERN
           (pair
             (sym :type)
-            (sym {:request :feature :routing :view}))
+            (sym {:request :feature :system :routing :view}))
         PATTERN
 
         def_node_matcher :shared_group?, <<-PATTERN

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     RUBY
   end
 
+  it 'ignores system specs' do
+    expect_no_offenses(<<-RUBY)
+      describe 'my new system test', type: :system do
+      end
+    RUBY
+  end
+
   it 'ignores feature specs when RSpec.describe is used' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe 'my new feature', type: :feature do


### PR DESCRIPTION
…he new-ish rails system tests.


Updates `describe_class` to account for RSpecs `:system` wrapper of rails system tests for integration/feature testing. See comments from RSpec and the example test describe on line 18.

![image](https://user-images.githubusercontent.com/10551597/34018086-72accbea-e0f6-11e7-9b55-92dda9ceb0ac.png)
 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
