### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,8 @@ addons:
   code_climate:
     repo_token: ee08f267b6e437b1e68aeb024266ebaa8bf4ed474490e145ce8ad113e117d9b1
 
-before_install: gem update --remote bundler
+before_install:
+  - gem update --system 2.6.14
+  - gem install bundler -v 1.15.4
+
 script: bundle exec rake


### PR DESCRIPTION
Temporarily fix the Travis build by installing working versions of rubygems and bundler. I’ve borrowed this “fix” from Rails: rails/rails#31541

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.