### PR TITLE
Fix InstanceVariable offense when dynamic class uses instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updates `describe_class` to account for RSpecs `:system` wrapper of rails system tests. ([@EliseFitz15][])
 * Add `RSpec/ExpectChange` cop to enforce consistent usage of the change matcher. ([@Darhazer][])
 * Add autocorrect support to `RSpec/LetBeforeExamples`. ([@Darhazer][])
+* Fix `RSpec/InstanceVariable` flagging instance variables inside dynamically defined class. ([@Darhazer][])
 
 ## 1.21.0 (2017-12-13)
 

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -36,6 +36,24 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     RUBY
   end
 
+  it 'ignores an instance variable inside a dynamic class' do
+    expect_no_offenses(<<-RUBY)
+      describe MyClass do
+        let(:object) do
+          Class.new(OtherClass) do
+            def initialize(resource)
+              @resource = resource
+            end
+
+            def serialize
+              @resource.to_json
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
   # Regression test for nevir/rubocop-rspec#115
   it 'ignores instance variables outside of specs' do
     expect_no_offenses(<<-RUBY, 'lib/source_code.rb')


### PR DESCRIPTION
This fixes #506

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

