### PR TITLE
Use Circle CI instead of Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+version: 2
+
+jobs:
+  ruby-2.1:
+    docker:
+      - image: circleci/ruby:2.1
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+  ruby-2.2:
+    docker:
+      - image: circleci/ruby:2.2
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+  ruby-2.3:
+    docker:
+      - image: circleci/ruby:2.3
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+  ruby-2.4:
+    docker:
+      - image: circleci/ruby:2.4
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+  ruby-2.5:
+    docker:
+      - image: circleci/ruby:2.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+  ruby-latest:
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+  jruby:
+    docker:
+      - image: circleci/jruby:9.1
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - ruby-2.1
+      - ruby-2.2
+      - ruby-2.3
+      - ruby-2.4
+      - ruby-2.5
+      - ruby-latest
+      - jruby


### PR DESCRIPTION
For a while now I’ve been wanting to switch from Travis CI to Circle CI. In my experience, Circle is much, much faster than Travis, and seeing how we suddenly get weird errors when trying out a new Ruby (#526), I’m leaning even more towards Circle.

There are a few TODOs though:

- [x] Set up Circle CI (https://circleci.com/signup/ -> Sign up with GitHub -> Public Repos Only) for backus/rubocop-rspec
- [ ] ~Remove Travis config~
- [ ] ~Disconnect Travis?~
- [ ] ~Change Travis “status image” in the Readme to a Circle equivalent.~
- [ ] ~Fix codeclimate integration.~

The last 4 items, we’ll do later.