### PR TITLE
Fix with method in RSpec/ReturnFromStub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/ReturnFromStub` cop for `with` method. ([@flyerhzm][])
+
 ## 1.22.0 (2018-01-10)
 
 * Updates `describe_class` to account for RSpecs `:system` wrapper of rails system tests. ([@EliseFitz15][])
@@ -290,3 +292,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@pirj]: https://github.com/pirj
 [@telmofcosta]: https://github.com/telmofcosta
 [@EliseFitz15]: https://github.com/EliseFitz15
+[@flyerhzm]: https://github.com/flyerhzm

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -128,6 +128,10 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
                      'allow(Foo).to receive(:bar) {}',
                      'allow(Foo).to receive(:bar).and_return(nil)'
 
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).with(1) {}',
+                     'allow(Foo).to receive(:bar).with(1).and_return(nil)'
+
     original = <<-RUBY
       allow(Foo).to receive(:bar) do
         'You called ' \\
@@ -190,6 +194,10 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
     include_examples 'autocorrect',
                      'allow(Foo).to receive(:bar).and_return(foo: 42)',
                      'allow(Foo).to receive(:bar) { { foo: 42 } }'
+
+    include_examples 'autocorrect',
+                     'allow(Foo).to receive(:bar).with(1).and_return(foo: 42)',
+                     'allow(Foo).to receive(:bar).with(1) { { foo: 42 } }'
 
     original = <<-RUBY
       allow(Foo).to receive(:bar).and_return(


### PR DESCRIPTION
`RSpec/ReturnFromStub` cop ignores `with` method right now, e.g. it replaces

```
allow(Foo).to receive(:bar).with(1) {}
```

with

```
allow(Foo).to receive(:bar).and_return(nil)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
