### PR TITLE
Refined Circle CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,16 @@ jobs:
       - image: circleci/jruby:9.1
     steps:
       - checkout
-      - run: bundle install
+      - run: bundle lock
+      - restore_cache:
+          keys:
+            - bundle-v1-{{ checksum "Gemfile.lock" }}
+            - bundle-v1-
+      - run: bundle install --path vendor/bundle
+      - save_cache:
+          key: bundle-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
       - run: rake internal_investigation spec
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,6 @@ jobs:
       - checkout
       - run: bundle install
       - run: rake
-  ruby-latest:
-    docker:
-      - image: circleci/ruby:latest
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake
   jruby:
     docker:
       - image: circleci/jruby:9.1
@@ -60,5 +53,4 @@ workflows:
       - ruby-2.3
       - ruby-2.4
       - ruby-2.5
-      - ruby-latest
       - jruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,116 @@
 version: 2
 
 jobs:
-  ruby-2.1:
-    docker:
-      - image: circleci/ruby:2.1
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake
-  ruby-2.2:
-    docker:
-      - image: circleci/ruby:2.2
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake
-  ruby-2.3:
-    docker:
-      - image: circleci/ruby:2.3
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake
-  ruby-2.4:
-    docker:
-      - image: circleci/ruby:2.4
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake
-  ruby-2.5:
+  confirm_config:
     docker:
       - image: circleci/ruby:2.5
     steps:
       - checkout
       - run: bundle install
-      - run: rake
+      - run: rake confirm_config
+
+  # Ruby 2.1
+  ruby-2.1-rspec:
+    docker:
+      - image: circleci/ruby:2.1
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake spec
+  ruby-2.1-rubocop:
+    docker:
+      - image: circleci/ruby:2.1
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake internal_investigation
+
+  # Ruby 2.2
+  ruby-2.2-rspec:
+    docker:
+      - image: circleci/ruby:2.2
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake spec
+  ruby-2.2-rubocop:
+    docker:
+      - image: circleci/ruby:2.2
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake internal_investigation
+
+  # Ruby 2.3
+  ruby-2.3-rspec:
+    docker:
+      - image: circleci/ruby:2.3
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake spec
+  ruby-2.3-rubocop:
+    docker:
+      - image: circleci/ruby:2.3
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake internal_investigation
+
+  # Ruby 2.4
+  ruby-2.4-rspec:
+    docker:
+      - image: circleci/ruby:2.4
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake spec
+  ruby-2.4-rubocop:
+    docker:
+      - image: circleci/ruby:2.4
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake internal_investigation
+
+  # Ruby 2.5
+  ruby-2.5-rspec:
+    docker:
+      - image: circleci/ruby:2.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake spec
+  ruby-2.5-rubocop:
+    docker:
+      - image: circleci/ruby:2.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run: rake internal_investigation
+
+  # JRuby
   jruby:
     docker:
       - image: circleci/jruby:9.1
     steps:
       - checkout
       - run: bundle install
-      - run: rake
+      - run: rake internal_investigation spec
 
 workflows:
   version: 2
   build:
     jobs:
-      - ruby-2.1
-      - ruby-2.2
-      - ruby-2.3
-      - ruby-2.4
-      - ruby-2.5
+      - confirm_config
+      - ruby-2.1-rspec
+      - ruby-2.1-rubocop
+      - ruby-2.2-rspec
+      - ruby-2.2-rubocop
+      - ruby-2.3-rspec
+      - ruby-2.3-rubocop
+      - ruby-2.4-rspec
+      - ruby-2.4-rubocop
+      - ruby-2.5-rspec
+      - ruby-2.5-rubocop
       - jruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,14 +85,26 @@ workflows:
   build:
     jobs:
       - confirm_config
-      - ruby-2.1-rspec
-      - ruby-2.1-rubocop
-      - ruby-2.2-rspec
-      - ruby-2.2-rubocop
-      - ruby-2.3-rspec
-      - ruby-2.3-rubocop
-      - ruby-2.4-rspec
-      - ruby-2.4-rubocop
-      - ruby-2.5-rspec
-      - ruby-2.5-rubocop
+
+      # Use `requires: [confirm_config]` to trick Circle CI into starting the slow jruby job early.
+      - ruby-2.1-rspec:
+          requires: [confirm_config]
+      - ruby-2.1-rubocop:
+          requires: [confirm_config]
+      - ruby-2.2-rspec:
+          requires: [confirm_config]
+      - ruby-2.2-rubocop:
+          requires: [confirm_config]
+      - ruby-2.3-rspec:
+          requires: [confirm_config]
+      - ruby-2.3-rubocop:
+          requires: [confirm_config]
+      - ruby-2.4-rspec:
+          requires: [confirm_config]
+      - ruby-2.4-rubocop:
+          requires: [confirm_config]
+      - ruby-2.5-rspec:
+          requires: [confirm_config]
+      - ruby-2.5-rubocop:
+          requires: [confirm_config]
       - jruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 version: 2
 
+rspec: &rspec
+  steps:
+    - checkout
+    - run: bundle install
+    - run: rake spec
+
+rubocop: &rubocop
+  steps:
+    - checkout
+    - run: bundle install
+    - run: rake internal_investigation
+
 jobs:
   confirm_config:
     docker:
@@ -13,81 +25,51 @@ jobs:
   ruby-2.1-rspec:
     docker:
       - image: circleci/ruby:2.1
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake spec
+    <<: *rspec
   ruby-2.1-rubocop:
     docker:
       - image: circleci/ruby:2.1
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake internal_investigation
+    <<: *rubocop
 
   # Ruby 2.2
   ruby-2.2-rspec:
     docker:
       - image: circleci/ruby:2.2
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake spec
+    <<: *rspec
   ruby-2.2-rubocop:
     docker:
       - image: circleci/ruby:2.2
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake internal_investigation
+    <<: *rubocop
 
   # Ruby 2.3
   ruby-2.3-rspec:
     docker:
       - image: circleci/ruby:2.3
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake spec
+    <<: *rspec
   ruby-2.3-rubocop:
     docker:
       - image: circleci/ruby:2.3
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake internal_investigation
+    <<: *rubocop
 
   # Ruby 2.4
   ruby-2.4-rspec:
     docker:
       - image: circleci/ruby:2.4
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake spec
+    <<: *rspec
   ruby-2.4-rubocop:
     docker:
       - image: circleci/ruby:2.4
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake internal_investigation
+    <<: *rubocop
 
   # Ruby 2.5
   ruby-2.5-rspec:
     docker:
       - image: circleci/ruby:2.5
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake spec
+    <<: *rspec
   ruby-2.5-rubocop:
     docker:
       - image: circleci/ruby:2.5
-    steps:
-      - checkout
-      - run: bundle install
-      - run: rake internal_investigation
+    <<: *rubocop
 
   # JRuby
   jruby:


### PR DESCRIPTION
With this PR we run a number of small, fast jobs:

- a `confirm_config` job running on Ruby 2.5.
- an `rspec` job and an `rubocop` job for each of the Ruby versions 2.1, 2.2, 2.3, 2.4 and 2.5.
- a combined `rspec` and `rubocop` job running on JRuby, with caching around the `bundle install` step to make it a bit faster.

We can run 4 jobs in parallel on Circle CI. Since the JRuby job is significantly slower than any of the other, I wanted to ensure that it one of the first 4 being started. I accomplished this by making all the regular `rspec` and `rubocop` jobs being “dependent” on the very fast `confirm_config` job:

![circle-ci-workflow](https://user-images.githubusercontent.com/22333/34979741-8a5d636a-faa2-11e7-9195-19bfaea16dcb.png)

Example build time before: [1:39](https://circleci.com/workflow-run/8c8c6d0d-c779-48d0-a2f3-e5ea9cf784c0)
Example build time after: [1:13](https://circleci.com/workflow-run/e28bed8c-9a46-4238-98ce-d70d7b75b8ee)

Actual build times will of course vary a bit (~15 seconds).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
