### PR TITLE
Fix RSpec/DescribedClass with empty block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix error in `RSpec/DescribedClass` when working on an empty `describe` block. ([@bquorning][])
+
 ## 1.22.1 (2018-01-17)
 
 * Fix false positives in `RSpec/ReturnFromStub`. ([@Darhazer][])

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -50,6 +50,8 @@ module RuboCop
 
         def on_block(node)
           describe, described_class, body = described_constant(node)
+
+          return if body.nil?
           return unless top_level_describe?(describe)
 
           # in case we explicit style is used, this cop needs to remember what's

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -49,14 +49,12 @@ module RuboCop
         def_node_matcher :scope_changing_syntax?, '{def class module}'
 
         def on_block(node)
-          describe, described_class, body = described_constant(node)
+          # In case the explicit style is used, we needs to remember what's
+          # being described. Thus, we use an ivar for @described_class.
+          describe, @described_class, body = described_constant(node)
 
           return if body.nil?
           return unless top_level_describe?(describe)
-
-          # in case we explicit style is used, this cop needs to remember what's
-          # being described, so to replace described_class with the constant
-          @described_class = described_class
 
           find_usage(body) do |match|
             add_offense(

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -202,6 +202,13 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
+    it 'accepts an empty block' do
+      expect_no_offenses(<<-RUBY)
+        describe MyClass do
+        end
+      RUBY
+    end
+
     include_examples 'autocorrect',
                      'describe(Foo) { include Foo }',
                      'describe(Foo) { include described_class }'


### PR DESCRIPTION
Fixes #541.

`RSpec/DescribedClass` cop would raise an exception when encountering an empty `describe` block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.