### PR TITLE
[#544] ADD Rails/HttpStatus cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbol). ([@anthony-robin][], [@jojos003][])
+
 ## 1.22.2 (2018-02-01)
 
 * Fix error in `RSpec/DescribedClass` when working on an empty `describe` block. ([@bquorning][])
@@ -298,3 +300,5 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@pirj]: https://github.com/pirj
 [@telmofcosta]: https://github.com/telmofcosta
 [@EliseFitz15]: https://github.com/EliseFitz15
+[@anthony-robin]: https://github.com/anthony-robin
+[@jojos003]: https://github.com/jojos003

--- a/bin/build_config
+++ b/bin/build_config
@@ -9,7 +9,7 @@ require 'rubocop/rspec/description_extractor'
 require 'rubocop/rspec/config_formatter'
 
 glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec',
-                 '{,capybara,factory_bot}', '*.rb')
+                 '{,capybara,factory_bot,rails}', '*.rb')
 YARD.parse(Dir[glob], [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h

--- a/config/default.yml
+++ b/config/default.yml
@@ -368,3 +368,12 @@ FactoryBot/DynamicAttributeDefinedStatically:
   Description: Prefer declaring dynamic attribute values in a block.
   Enabled: true
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/DynamicAttributeDefinedStatically
+
+Rails/HttpStatus:
+  Description: Enforces use of symbolic or numeric value to describe HTTP status.
+  Enabled: true
+  EnforcedStyle: symbol
+  SupportedStyles:
+  - numeric
+  - symbol
+  StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module Rails
+        # Enforces use of symbolic or numeric value to describe HTTP status.
+        #
+        # @example `EnforcedStyle: symbol` (default)
+        #   # bad
+        #   it { is_expected.to have_http_status 200 }
+        #   it { is_expected.to have_http_status 404 }
+        #
+        #   # good
+        #   it { is_expected.to have_http_status :ok }
+        #   it { is_expected.to have_http_status :not_found }
+        #   it { is_expected.to have_http_status :success }
+        #   it { is_expected.to have_http_status :error }
+        #
+        # @example `EnforcedStyle: numeric`
+        #   # bad
+        #   it { is_expected.to have_http_status :ok }
+        #   it { is_expected.to have_http_status :not_found }
+        #
+        #   # good
+        #   it { is_expected.to have_http_status 200 }
+        #   it { is_expected.to have_http_status 404 }
+        #   it { is_expected.to have_http_status :success }
+        #   it { is_expected.to have_http_status :error }
+        #
+        class HttpStatus < Cop
+          begin
+            require 'rack/utils'
+            AUTOCORRECTS = true
+          rescue LoadError
+            AUTOCORRECTS = false
+          end
+
+          include ConfigurableEnforcedStyle
+
+          MSG = 'Prefer `%<prefer>s` over `%<current>s` '\
+                'to describe HTTP status code.'.freeze
+          WHITELIST_STATUS = %i[error success missing redirect].freeze
+
+          def_node_matcher :http_status, <<-PATTERN
+            (send nil? :have_http_status ${int sym})
+          PATTERN
+
+          def on_send(node) # rubocop:disable Metrics/CyclomaticComplexity
+            http_status(node) do |ast_node|
+              if style == :numeric
+                return if ast_node.int_type?
+                return if ast_node.sym_type? &&
+                    WHITELIST_STATUS.include?(ast_node.value)
+              end
+
+              return if style == :symbol && ast_node.sym_type?
+
+              add_offense(ast_node)
+            end
+          end
+
+          def message(node)
+            prefer, current = message_without_autocorrect unless AUTOCORRECTS
+            prefer, current = message_for_autocorrect(node) if AUTOCORRECTS
+
+            format(MSG, prefer: prefer, current: current)
+          end
+
+          if AUTOCORRECTS
+            def autocorrect(node)
+              replacement = new_value(node)
+              return if replacement.nil?
+
+              lambda do |corrector|
+                corrector.replace(node.loc.expression, replacement.to_s)
+              end
+            end
+          end
+
+          private
+
+          def new_value(node)
+            case style
+            when :numeric
+              numeric, = symbolic_to_numeric_value(node)
+              numeric
+            when :symbol
+              symbol, = numeric_to_symbolic_value(node)
+              symbol
+            end
+          end
+
+          def numeric_to_symbolic_value(node)
+            numeric = node.source.to_i
+            symbol = ":#{::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(numeric)}"
+
+            [symbol, numeric]
+          end
+
+          def symbolic_to_numeric_value(node)
+            symbol = node.value
+            numeric = ::Rack::Utils::SYMBOL_TO_STATUS_CODE[symbol]
+
+            [numeric, symbol]
+          end
+
+          def message_for_autocorrect(node)
+            if style == :numeric
+              prefer, current = symbolic_to_numeric_value(node)
+              return [prefer, ":#{current}"]
+            end
+
+            numeric_to_symbolic_value(node)
+          end
+
+          def message_without_autocorrect
+            return %i[numeric symbolic] if style == :numeric
+
+            %i[symbolic numeric]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -3,6 +3,8 @@ require_relative 'rspec/capybara/feature_methods'
 
 require_relative 'rspec/factory_bot/dynamic_attribute_defined_statically'
 
+require_relative 'rspec/rails/http_status'
+
 require_relative 'rspec/align_left_let_brace'
 require_relative 'rspec/align_right_let_brace'
 require_relative 'rspec/any_instance'

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
-      NAMESPACES = /^(RSpec|Capybara|FactoryBot)/
+      NAMESPACES = /^(RSpec|Capybara|FactoryBot|Rails)/
       STYLE_GUIDE_BASE_URL = 'http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'.freeze
 
       def initialize(config, descriptions)

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rubocop', '>= 0.52.1'
 
+  spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
   spec.add_development_dependency 'simplecov'

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe 'config/default.yml' do
     namespaces = {
       'rspec' => 'RSpec',
       'capybara' => 'Capybara',
-      'factory_bot' => 'FactoryBot'
+      'factory_bot' => 'FactoryBot',
+      'rails' => 'Rails'
     }
     glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'rspec',
-                                 '{,capybara,factory_bot}', '*.rb')
+                                 '{,capybara,factory_bot,rails}', '*.rb')
     cop_names =
       Pathname.glob(glob).map do |file|
         file_name = file.basename('.rb').to_s

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'when EnforcedStyle is `symbol`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symbol' } }
+
+    it 'registers an offense when using numeric value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status 200 }
+                                             ^^^ Prefer `:ok` over `200` to describe HTTP status code.
+      RUBY
+    end
+
+    it 'does not register an offense when using symbol value' do
+      expect_no_offenses(<<-RUBY)
+        it { is_expected.to have_http_status :ok }
+      RUBY
+    end
+
+    include_examples 'autocorrect',
+                     'it { is_expected.to have_http_status 200 }',
+                     'it { is_expected.to have_http_status :ok }'
+
+    include_examples 'autocorrect',
+                     'it { is_expected.to have_http_status 404 }',
+                     'it { is_expected.to have_http_status :not_found }'
+
+    context 'with parenthesis' do
+      include_examples 'autocorrect',
+                       'it { is_expected.to have_http_status(200) }',
+                       'it { is_expected.to have_http_status(:ok) }'
+
+      include_examples 'autocorrect',
+                       'it { is_expected.to have_http_status(404) }',
+                       'it { is_expected.to have_http_status(:not_found) }'
+    end
+
+    context 'when rack is not loaded' do
+      before { stub_const("#{described_class}::AUTOCORRECTS", false) }
+
+      it 'registers an offense when using numeric value' do
+        expect_offense(<<-RUBY)
+          it { is_expected.to have_http_status 200 }
+                                               ^^^ Prefer `symbolic` over `numeric` to describe HTTP status code.
+        RUBY
+      end
+    end
+  end
+
+  context 'when EnforcedStyle is `numeric`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'numeric' } }
+
+    it 'registers an offense when using symbolic value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status :ok }
+                                             ^^^ Prefer `200` over `:ok` to describe HTTP status code.
+      RUBY
+    end
+
+    it 'does not register an offense when using numeric value' do
+      expect_no_offenses(<<-RUBY)
+        it { is_expected.to have_http_status 200 }
+      RUBY
+    end
+
+    it 'does not register an offense when using whitelisted symbols' do
+      expect_no_offenses(<<-RUBY)
+        it { is_expected.to have_http_status :error }
+        it { is_expected.to have_http_status :success }
+        it { is_expected.to have_http_status :missing }
+        it { is_expected.to have_http_status :redirect }
+      RUBY
+    end
+
+    include_examples 'autocorrect',
+                     'it { is_expected.to have_http_status :ok }',
+                     'it { is_expected.to have_http_status 200 }'
+
+    include_examples 'autocorrect',
+                     'it { is_expected.to have_http_status :not_found }',
+                     'it { is_expected.to have_http_status 404 }'
+
+    context 'with parenthesis' do
+      include_examples 'autocorrect',
+                       'it { is_expected.to have_http_status(:ok) }',
+                       'it { is_expected.to have_http_status(200) }'
+
+      include_examples 'autocorrect',
+                       'it { is_expected.to have_http_status(:not_found) }',
+                       'it { is_expected.to have_http_status(404) }'
+    end
+
+    context 'when rack is not loaded' do
+      before { stub_const("#{described_class}::AUTOCORRECTS", false) }
+
+      it 'registers an offense when using numeric value' do
+        expect_offense(<<-RUBY)
+          it { is_expected.to have_http_status :ok }
+                                               ^^^ Prefer `numeric` over `symbolic` to describe HTTP status code.
+        RUBY
+      end
+    end
+  end
+end


### PR DESCRIPTION
This cop enforces consistent use of `symbol` or `numeric`
value to describe HTTP status.

Example `EnforcedStyle: symbol` (default)
```ruby
  # bad
  it { is_expected.to have_http_status 200 }
  it { is_expected.to have_http_status 404 }

  # good
  it { is_expected.to have_http_status :ok }
  it { is_expected.to have_http_status :not_found }
  it { is_expected.to have_http_status :success }
  it { is_expected.to have_http_status :error }
```

Example `EnforcedStyle: numeric`
```ruby
  # bad
  it { is_expected.to have_http_status :ok }
  it { is_expected.to have_http_status :not_found }

  # good
  it { is_expected.to have_http_status 200 }
  it { is_expected.to have_http_status 404 }
  it { is_expected.to have_http_status :success }
  it { is_expected.to have_http_status :error }
```

Closes #544

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [x] Added the new cop to `config/default.yml`.
* [x] The cop includes examples of good and bad code.
* [x] You have tests for both code that should be reported and code that is good.
