### PR TITLE
Simplify namespace regex and glob patterns

### DIFF
--- a/bin/build_config
+++ b/bin/build_config
@@ -8,8 +8,8 @@ require 'rubocop-rspec'
 require 'rubocop/rspec/description_extractor'
 require 'rubocop/rspec/config_formatter'
 
-cops = '{*.rb,capybara/*.rb,factory_bot/*.rb}'
-glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec', cops)
+glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec',
+                 '{,capybara,factory_bot}', '*.rb')
 YARD.parse(Dir[glob], [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
-      NAMESPACES = /^(#{Regexp.union('RSpec', 'Capybara', 'FactoryBot')})/
+      NAMESPACES = /^(RSpec|Capybara|FactoryBot)/
       STYLE_GUIDE_BASE_URL = 'http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'.freeze
 
       def initialize(config, descriptions)

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'config/default.yml' do
       'capybara' => 'Capybara',
       'factory_bot' => 'FactoryBot'
     }
-    glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop',
-                                 'rspec', '{capybara/,,factory_bot/}*.rb')
+    glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'rspec',
+                                 '{,capybara,factory_bot}', '*.rb')
     cop_names =
       Pathname.glob(glob).map do |file|
         file_name = file.basename('.rb').to_s


### PR DESCRIPTION
We currently have the namespaces `Capybara` (capybara), `FactoryBot` (factory_bot), and `RSpec` (with no sub-folder).

With a simpler regex and more consistent glob patterns, I hope it will be simpler to figure out which code to change when adding a new namespace. It doesn’t happen often enough that I want to write actual documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
