### PR TITLE
Change HttpStatus style name symbol to symbolic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master (Unreleased)
 
-* Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbol). ([@anthony-robin][], [@jojos003][])
+* Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbolic). ([@anthony-robin][], [@jojos003][])
 
 ## 1.22.2 (2018-02-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -372,8 +372,8 @@ FactoryBot/DynamicAttributeDefinedStatically:
 Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true
-  EnforcedStyle: symbol
+  EnforcedStyle: symbolic
   SupportedStyles:
   - numeric
-  - symbol
+  - symbolic
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -6,7 +6,7 @@ module RuboCop
       module Rails
         # Enforces use of symbolic or numeric value to describe HTTP status.
         #
-        # @example `EnforcedStyle: symbol` (default)
+        # @example `EnforcedStyle: symbolic` (default)
         #   # bad
         #   it { is_expected.to have_http_status 200 }
         #   it { is_expected.to have_http_status 404 }
@@ -54,7 +54,7 @@ module RuboCop
                     WHITELIST_STATUS.include?(ast_node.value)
               end
 
-              return if style == :symbol && ast_node.sym_type?
+              return if style == :symbolic && ast_node.sym_type?
 
               add_offense(ast_node)
             end
@@ -85,7 +85,7 @@ module RuboCop
             when :numeric
               numeric, = symbolic_to_numeric_value(node)
               numeric
-            when :symbol
+            when :symbolic
               symbol, = numeric_to_symbolic_value(node)
               symbol
             end

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'when EnforcedStyle is `symbol`' do
-    let(:cop_config) { { 'EnforcedStyle' => 'symbol' } }
+  context 'when EnforcedStyle is `symbolic`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symbolic' } }
 
     it 'registers an offense when using numeric value' do
       expect_offense(<<-RUBY)
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
       RUBY
     end
 
-    it 'does not register an offense when using symbol value' do
+    it 'does not register an offense when using symbolic value' do
       expect_no_offenses(<<-RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY


### PR DESCRIPTION
I need a better English speaker than myself to confirm this: Should the supported styles for the new `HttpStatus` cop be

1. “symbol” and “numeric”, or
2. “symbolic” and “numeric”?

cc @anthony-robin

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
