### PR TITLE
Make Travis tests run faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,9 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 2.1.10
-  - 2.2.8
-  - 2.3.5
   - 2.4.2
-  - ruby-head
-  - jruby-9.1.13.0
 
 matrix:
-  allow_failures:
-    - rvm: ruby-head
   fast_finish: true
 
 addons:


### PR DESCRIPTION
Until we can completely disable Travis, make the tests run faster by skipping, among others, JRuby.

Now Travis will take ~1.5 minutes instead of ~7.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
