### PR TITLE
Refactoring of Rails/HttpStatus 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master (Unreleased)
 
-* Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbol). ([@anthony-robin][], [@jojos003][])
+* Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbolic). ([@anthony-robin][], [@jojos003][])
 
 ## 1.22.2 (2018-02-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -372,8 +372,8 @@ FactoryBot/DynamicAttributeDefinedStatically:
 Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true
-  EnforcedStyle: symbol
+  EnforcedStyle: symbolic
   SupportedStyles:
   - numeric
-  - symbol
+  - symbolic
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -6,7 +6,7 @@ module RuboCop
       module Rails
         # Enforces use of symbolic or numeric value to describe HTTP status.
         #
-        # @example `EnforcedStyle: symbol` (default)
+        # @example `EnforcedStyle: symbolic` (default)
         #   # bad
         #   it { is_expected.to have_http_status 200 }
         #   it { is_expected.to have_http_status 404 }
@@ -54,7 +54,7 @@ module RuboCop
                     WHITELIST_STATUS.include?(ast_node.value)
               end
 
-              return if style == :symbol && ast_node.sym_type?
+              return if style == :symbolic && ast_node.sym_type?
 
               add_offense(ast_node)
             end
@@ -85,7 +85,7 @@ module RuboCop
             when :numeric
               numeric, = symbolic_to_numeric_value(node)
               numeric
-            when :symbol
+            when :symbolic
               symbol, = numeric_to_symbolic_value(node)
               symbol
             end

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -31,9 +31,9 @@ module RuboCop
         class HttpStatus < Cop
           begin
             require 'rack/utils'
-            AUTOCORRECTS = true
+            RACK_LOADED = true
           rescue LoadError
-            AUTOCORRECTS = false
+            RACK_LOADED = false
           end
 
           include ConfigurableEnforcedStyle
@@ -61,20 +61,22 @@ module RuboCop
           end
 
           def message(node)
-            prefer, current = message_without_autocorrect unless AUTOCORRECTS
-            prefer, current = message_for_autocorrect(node) if AUTOCORRECTS
+            prefer, current = message_without_autocorrect unless RACK_LOADED
+            prefer, current = message_for_autocorrect(node) if RACK_LOADED
 
             format(MSG, prefer: prefer, current: current)
           end
 
-          if AUTOCORRECTS
-            def autocorrect(node)
-              replacement = new_value(node)
-              return if replacement.nil?
+          def support_autocorrect?
+            RACK_LOADED
+          end
 
-              lambda do |corrector|
-                corrector.replace(node.loc.expression, replacement.to_s)
-              end
+          def autocorrect(node)
+            replacement = new_value(node)
+            return if replacement.nil?
+
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, replacement.to_s)
             end
           end
 

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -38,33 +38,16 @@ module RuboCop
 
           include ConfigurableEnforcedStyle
 
-          MSG = 'Prefer `%<prefer>s` over `%<current>s` '\
-                'to describe HTTP status code.'.freeze
-          WHITELIST_STATUS = %i[error success missing redirect].freeze
-
           def_node_matcher :http_status, <<-PATTERN
             (send nil? :have_http_status ${int sym})
           PATTERN
 
-          def on_send(node) # rubocop:disable Metrics/CyclomaticComplexity
+          def on_send(node)
             http_status(node) do |ast_node|
-              if style == :numeric
-                return if ast_node.int_type?
-                return if ast_node.sym_type? &&
-                    WHITELIST_STATUS.include?(ast_node.value)
-              end
-
-              return if style == :symbolic && ast_node.sym_type?
-
-              add_offense(ast_node)
+              checker = checker_class.new(ast_node)
+              return unless checker.offensive?
+              add_offense(checker.node, message: checker.message)
             end
-          end
-
-          def message(node)
-            prefer, current = message_without_autocorrect unless RACK_LOADED
-            prefer, current = message_for_autocorrect(node) if RACK_LOADED
-
-            format(MSG, prefer: prefer, current: current)
           end
 
           def support_autocorrect?
@@ -72,54 +55,105 @@ module RuboCop
           end
 
           def autocorrect(node)
-            replacement = new_value(node)
-            return if replacement.nil?
-
             lambda do |corrector|
-              corrector.replace(node.loc.expression, replacement.to_s)
+              checker = checker_class.new(node)
+              corrector.replace(node.loc.expression, checker.preferred_style)
             end
           end
 
           private
 
-          def new_value(node)
+          def checker_class
             case style
-            when :numeric
-              numeric, = symbolic_to_numeric_value(node)
-              numeric
             when :symbolic
-              symbol, = numeric_to_symbolic_value(node)
-              symbol
+              SymbolicStyleChecker
+            when :numeric
+              NumericStyleChecker
             end
           end
 
-          def numeric_to_symbolic_value(node)
-            numeric = node.source.to_i
-            symbol = ":#{::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(numeric)}"
+          # :nodoc:
+          class SymbolicStyleChecker
+            MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
+                  'to describe HTTP status code.'.freeze
+            DEFAULT_MSG = 'Prefer `symbolic` over `numeric` ' \
+                  'to describe HTTP status code.'.freeze
 
-            [symbol, numeric]
-          end
-
-          def symbolic_to_numeric_value(node)
-            symbol = node.value
-            numeric = ::Rack::Utils::SYMBOL_TO_STATUS_CODE[symbol]
-
-            [numeric, symbol]
-          end
-
-          def message_for_autocorrect(node)
-            if style == :numeric
-              prefer, current = symbolic_to_numeric_value(node)
-              return [prefer, ":#{current}"]
+            attr_reader :node
+            def initialize(node)
+              @node = node
             end
 
-            numeric_to_symbolic_value(node)
+            def offensive?
+              !node.sym_type?
+            end
+
+            def message
+              if RACK_LOADED
+                format(MSG, prefer: preferred_style, current: number.to_s)
+              else
+                DEFAULT_MSG
+              end
+            end
+
+            def preferred_style
+              symbol.inspect
+            end
+
+            private
+
+            def symbol
+              ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(number)
+            end
+
+            def number
+              node.source.to_i
+            end
           end
 
-          def message_without_autocorrect
-            return %i[numeric symbolic] if style == :numeric
+          # :nodoc:
+          class NumericStyleChecker
+            MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
+                  'to describe HTTP status code.'.freeze
+            DEFAULT_MSG = 'Prefer `numeric` over `symbolic` ' \
+                  'to describe HTTP status code.'.freeze
 
-            %i[symbolic numeric]
+            WHITELIST_STATUS = %i[error success missing redirect].freeze
+
+            attr_reader :node
+            def initialize(node)
+              @node = node
+            end
+
+            def offensive?
+              !node.int_type? && !whitelisted_symbol?
+            end
+
+            def message
+              if RACK_LOADED
+                format(MSG, prefer: preferred_style, current: symbol.inspect)
+              else
+                DEFAULT_MSG
+              end
+            end
+
+            def preferred_style
+              number.to_s
+            end
+
+            private
+
+            def number
+              ::Rack::Utils::SYMBOL_TO_STATUS_CODE[symbol]
+            end
+
+            def symbol
+              node.value
+            end
+
+            def whitelisted_symbol?
+              node.sym_type? && WHITELIST_STATUS.include?(node.value)
+            end
           end
         end
       end

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'when EnforcedStyle is `symbol`' do
-    let(:cop_config) { { 'EnforcedStyle' => 'symbol' } }
+  context 'when EnforcedStyle is `symbolic`' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symbolic' } }
 
     it 'registers an offense when using numeric value' do
       expect_offense(<<-RUBY)
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
       RUBY
     end
 
-    it 'does not register an offense when using symbol value' do
+    it 'does not register an offense when using symbolic value' do
       expect_no_offenses(<<-RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
     end
 
     context 'when rack is not loaded' do
-      before { stub_const("#{described_class}::AUTOCORRECTS", false) }
+      before { stub_const("#{described_class}::RACK_LOADED", false) }
 
       it 'registers an offense when using numeric value' do
         expect_offense(<<-RUBY)
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
     end
 
     context 'when rack is not loaded' do
-      before { stub_const("#{described_class}::AUTOCORRECTS", false) }
+      before { stub_const("#{described_class}::RACK_LOADED", false) }
 
       it 'registers an offense when using numeric value' do
         expect_offense(<<-RUBY)


### PR DESCRIPTION
As mentioned in #546, I was never completely happy with the `Rails/HttpStatus` cop, so I finally got around to refactoring it.

By extracting all style specific logic into two classes (`SymbolicStyleChecker` and `NumericStyleChecker`), the configured `style` is only checked once, instead of every method having identical `if style == :foo ... else ...` statements.

I hope you can help me come up with better names for these “checker” classes. And if you have suggestions on how to avoid having `def_node_matcher` called *on the singleton class*, please let me know.

By the way don’t try to read the diff. Better to look separately at the cop [before](https://github.com/backus/rubocop-rspec/blob/219ef75583f82bcca636727afa1774ac1681e11f/lib/rubocop/cop/rspec/rails/http_status.rb) and [after](https://github.com/backus/rubocop-rspec/blob/rails-http-status-refactoring/lib/rubocop/cop/rspec/rails/http_status.rb).

cc @anthony-robin 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.