### PR TITLE
[NEW] Add `FactoryBot/StaticAttributeDefinedDynamically` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbolic). ([@anthony-robin][], [@jojos003][])
 * Fix false negative in `RSpec/ReturnFromStub` when a constant is being returned by the stub. ([@Darhazer][])
 * Fix `FactoryBot/DynamicAttributeDefinedStatically` to handle dynamic attributes inside arrays/hashes. ([@abrom][])
+* Add `FactoryBot/StaticAttributeDefinedDynamically` (based on dynamic attribute cop). ([@abrom][])
 
 ## 1.22.2 (2018-02-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -369,6 +369,11 @@ FactoryBot/DynamicAttributeDefinedStatically:
   Enabled: true
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/DynamicAttributeDefinedStatically
 
+FactoryBot/StaticAttributeDefinedDynamically:
+  Description: Prefer declaring static attribute values without a block.
+  Enabled: true
+  StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/StaticAttributeDefinedDynamically
+
 Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true

--- a/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
@@ -6,6 +6,8 @@ module RuboCop
       module FactoryBot
         # Prefer declaring dynamic attribute values in a block.
         #
+        # @see StaticAttributeDefinedDynamically
+        #
         # @example
         #   # bad
         #   kind [:active, :rejected].sample
@@ -18,15 +20,6 @@ module RuboCop
         #
         #   # good
         #   closed_at { 1.day.from_now }
-        #
-        #   # good
-        #   kind :static
-        #
-        #   # good
-        #   comments_count 0
-        #
-        #   # good
-        #   type User::MAGIC
         class DynamicAttributeDefinedStatically < Cop
           MSG = 'Use a block to set a dynamic value to an attribute.'.freeze
 

--- a/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module FactoryBot
+        # Prefer declaring static attribute values without a block.
+        #
+        # @see DynamicAttributeDefinedStatically
+        #
+        # @example
+        #   # bad
+        #   kind { :static }
+        #
+        #   # good
+        #   kind :static
+        #
+        #   # bad
+        #   comments_count { 0 }
+        #
+        #   # good
+        #   comments_count 0
+        #
+        #   # bad
+        #   type { User::MAGIC }
+        #
+        #   # good
+        #   type User::MAGIC
+        class StaticAttributeDefinedDynamically < Cop
+          MSG = 'Do not use a block to set a static value ' \
+                'to an attribute.'.freeze
+
+          def_node_matcher :block_value_matcher, <<-PATTERN
+            (block (send nil? _) _ $...)
+          PATTERN
+
+          def_node_search :factory_attributes, <<-PATTERN
+            (block (send nil? { :factory :trait } ...) _ { (begin $...) $(send ...) $(block ...) } )
+          PATTERN
+
+          def on_block(node)
+            factory_attributes(node).to_a.flatten.each do |attribute|
+              values = block_value_matcher(attribute)
+              next if values.to_a.none? { |v| static?(v) }
+              add_offense(attribute, location: :expression)
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(
+                node.loc.expression,
+                autocorrected_source(node)
+              )
+            end
+          end
+
+          private
+
+          def static?(node)
+            node.recursive_literal? || node.const_type?
+          end
+
+          def autocorrected_source(node)
+            if node.body.hash_type?
+              "#{node.send_node.source}(#{node.body.source})"
+            else
+              "#{node.send_node.source} #{node.body.source}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -2,6 +2,7 @@ require_relative 'rspec/capybara/current_path_expectation'
 require_relative 'rspec/capybara/feature_methods'
 
 require_relative 'rspec/factory_bot/dynamic_attribute_defined_statically'
+require_relative 'rspec/factory_bot/static_attribute_defined_dynamically'
 
 require_relative 'rspec/rails/http_status'
 

--- a/spec/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/LineLength
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::StaticAttributeDefinedDynamically do
+  # rubocop:enable Metrics/LineLength
+
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  %w[FactoryBot FactoryGirl].each do |factory_bot|
+    context "when using #{factory_bot}" do
+      it 'registers an offense for offending code' do
+        expect_offense(<<-RUBY)
+          #{factory_bot}.define do
+            factory :post do
+              kind { :static }
+              ^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              comments_count { 0 }
+              ^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              type { User::MAGIC }
+              ^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              description { nil }
+              ^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              recent_statuses { [:published, :draft] }
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              meta_tags { { foo: 1 } }
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+            end
+          end
+        RUBY
+      end
+
+      it 'registers an offense in a trait' do
+        expect_offense(<<-RUBY)
+          #{factory_bot}.define do
+            factory :post do
+              title "Something"
+              trait :something_else do
+                title { "Something Else" }
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'accepts valid factory definitions' do
+        expect_no_offenses(<<-RUBY)
+          #{factory_bot}.define do
+            factory :post do
+              trait :something_else do
+                title "Something Else"
+              end
+              title "Something"
+              comments_count 0
+              description { FFaker::Lorem.paragraph(10) }
+              tag Tag::MAGIC
+              recent_updates { [Time.current] }
+              meta_tags { { first_like: Time.current } }
+            end
+          end
+        RUBY
+      end
+
+      it 'does not add offense if out of factory girl block' do
+        expect_no_offenses(<<-RUBY)
+          kind { :static }
+          comments_count { 0 }
+          type { User::MAGIC }
+          description { nil }
+        RUBY
+      end
+
+      bad = <<-RUBY
+        #{factory_bot}.define do
+          factory :post do
+            comments_count { 0 }
+            type { User::MAGIC }
+            description { nil }
+            recent_statuses { [:published, :draft] }
+            meta_tags { { foo: 1 } }
+          end
+        end
+      RUBY
+
+      corrected = <<-RUBY
+        #{factory_bot}.define do
+          factory :post do
+            comments_count 0
+            type User::MAGIC
+            description nil
+            recent_statuses [:published, :draft]
+            meta_tags({ foo: 1 })
+          end
+        end
+      RUBY
+
+      include_examples 'autocorrect', bad, corrected
+    end
+  end
+end


### PR DESCRIPTION
Adds new FactoryBot cop to check that static values are defined as such. I'm no ruby AST expert so it'd be great to get some feedback on this.

@jonatas, I've based this on your original dynamic FactoryBot check so you've probably got thoughts about this?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [x] Added the new cop to `config/default.yml`.
* [x] The cop includes examples of good and bad code.
* [x] You have tests for both code that should be reported and code that is good.
