### PR TITLE
[FIX #555] FactoryBot/DynamicAttributeDefinedStatically handle wrapped dynamic values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbolic). ([@anthony-robin][], [@jojos003][])
 * Fix false negative in `RSpec/ReturnFromStub` when a constant is being returned by the stub. ([@Darhazer][])
+* Fix `FactoryBot/DynamicAttributeDefinedStatically` to handle dynamic attributes inside arrays/hashes. ([@abrom][])
 
 ## 1.22.2 (2018-02-01)
 
@@ -303,3 +304,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@EliseFitz15]: https://github.com/EliseFitz15
 [@anthony-robin]: https://github.com/anthony-robin
 [@jojos003]: https://github.com/jojos003
+[@abrom]: https://github.com/abrom

--- a/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
@@ -30,42 +30,56 @@ module RuboCop
         class DynamicAttributeDefinedStatically < Cop
           MSG = 'Use a block to set a dynamic value to an attribute.'.freeze
 
-          def_node_matcher :dynamic_defined_statically?, <<-PATTERN
-          (send nil? _ (send ... ))
+          def_node_matcher :value_matcher, <<-PATTERN
+            (send nil? _ $...)
           PATTERN
 
           def_node_search :factory_attributes, <<-PATTERN
-          (block (send nil? {:factory :trait} ...) _ { (begin $...) $(send ...) } )
+            (block (send nil? {:factory :trait} ...) _ { (begin $...) $(send ...) } )
           PATTERN
 
           def on_block(node)
-            return if node.method_name == :trait
             factory_attributes(node).to_a.flatten.each do |attribute|
-              if dynamic_defined_statically?(attribute)
-                add_offense(attribute, location: :expression)
-              end
+              next if value_matcher(attribute).to_a.all? { |v| static?(v) }
+              add_offense(attribute, location: :expression)
             end
           end
 
           def autocorrect(node)
-            if method_uses_parens?(node.location)
-              autocorrect_replacing_parens(node)
-            else
+            if !method_uses_parens?(node.location)
               autocorrect_without_parens(node)
+            elsif value_hash_without_braces?(node.descendants.first)
+              autocorrect_hash_without_braces(node)
+            else
+              autocorrect_replacing_parens(node)
             end
           end
 
           private
+
+          def static?(node)
+            node.recursive_literal? || node.const_type?
+          end
+
+          def value_hash_without_braces?(node)
+            node.hash_type? && !node.braces?
+          end
 
           def method_uses_parens?(location)
             return false unless location.begin && location.end
             location.begin.source == '(' && location.end.source == ')'
           end
 
-          def autocorrect_replacing_parens(node)
+          def autocorrect_hash_without_braces(node)
+            autocorrect_replacing_parens(node, ' { { ', ' } }')
+          end
+
+          def autocorrect_replacing_parens(node,
+                                           start_token = ' { ',
+                                           end_token = ' }')
             lambda do |corrector|
-              corrector.replace(node.location.begin, ' { ')
-              corrector.replace(node.location.end, ' }')
+              corrector.replace(node.location.begin, start_token)
+              corrector.replace(node.location.end, end_token)
             end
           end
 

--- a/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
               created_at 1.day.ago
               ^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
+              update_times [Time.current]
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
+              meta_tags(foo: Time.current)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to set a dynamic value to an attribute.
             end
           end
         RUBY
@@ -39,7 +43,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
         RUBY
       end
 
-      it 'accepts' do
+      it 'accepts valid factory definitions' do
         expect_no_offenses(<<-RUBY)
           #{factory_bot}.define do
             factory :post do
@@ -52,6 +56,9 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
               title "Static"
               description { FFaker::Lorem.paragraph(10) }
               tag Tag::MAGIC
+              recent_statuses [:published, :draft]
+              meta_tags(like_count: 2)
+              other_tags({ foo: nil })
             end
           end
         RUBY
@@ -62,6 +69,8 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
           status [:draft, :published].sample
           published_at 1.day.from_now
           created_at 1.day.ago
+          update_times [Time.current]
+          meta_tags(foo: Time.current)
         RUBY
       end
 
@@ -72,6 +81,13 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
             published_at 1.day.from_now
             created_at(1.day.ago)
             updated_at Time.current
+            update_times [Time.current]
+            meta_tags(foo: Time.current)
+            other_tags({ foo: Time.current })
+
+            trait :old do
+              published_at 1.week.ago
+            end
           end
         end
       RUBY
@@ -83,6 +99,13 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
             published_at { 1.day.from_now }
             created_at { 1.day.ago }
             updated_at { Time.current }
+            update_times { [Time.current] }
+            meta_tags { { foo: Time.current } }
+            other_tags { { foo: Time.current } }
+
+            trait :old do
+              published_at { 1.week.ago }
+            end
           end
         end
       RUBY


### PR DESCRIPTION
There are some edge cases relating to dynamic attributes not being detected when inside an array or hash, as per below:

```
# bad
recent_status_updates [1.hour.ago]
meta_tags(first_payment: 5.minutes.ago)

# good
recent_status_updates { [1.hour.ago] }
meta_tags { { first_payment: 5.minutes.ago } }
```

This change detects these edge cases and handles them appropriately.

Fixes #555 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
