### PR TITLE
Fix ReturnFromStub not detecting constants as static values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbolic). ([@anthony-robin][], [@jojos003][])
+* Fix false negative in `RSpec/ReturnFromStub` when a constant is being returned by the stub. ([@Darhazer][])
 
 ## 1.22.2 (2018-02-01)
 

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -92,7 +92,7 @@ module RuboCop
         end
 
         def dynamic?(node)
-          !node.recursive_literal?
+          !node.recursive_literal? && !node.const_type?
         end
 
         # :nodoc:

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
       RUBY
     end
 
+    it 'finds constants returned from block' do
+      expect_offense(<<-RUBY)
+        it do
+          allow(Foo).to receive(:bar) { Life::MEANING }
+                                      ^ Use `and_return` for static values.
+        end
+      RUBY
+    end
+
     it 'ignores dynamic values returned from block' do
       expect_no_offenses(<<-RUBY)
         it do


### PR DESCRIPTION
As pointed out in #555 `recursive_literal?` is missing const types. Although const is not strictly static (might be redefined) such behavior should not be encouraged, so I think we should handle const as static value.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
