### PR TITLE
Bugfix for custom HTTP status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* The `Rails/HttpStatus` cop is unavailable if the `rack` gem cannot be loaded. ([@bquorning][])
+
 ## 1.23.0 (2018-02-23)
 
 * Add `RSpec/Rails/HttpStatus` cop to enforce consistent usage of the status format (numeric or symbolic). ([@anthony-robin][], [@jojos003][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * The `Rails/HttpStatus` cop is unavailable if the `rack` gem cannot be loaded. ([@bquorning][])
+* Fix `Rails/HttpStatus` not working with custom HTTP status codes. ([@bquorning][])
 
 ## 1.23.0 (2018-02-23)
 

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -74,7 +74,7 @@ module RuboCop
             end
 
             def offensive?
-              !node.sym_type?
+              !node.sym_type? && !custom_http_status_code?
             end
 
             def message
@@ -93,6 +93,11 @@ module RuboCop
 
             def number
               node.source.to_i
+            end
+
+            def custom_http_status_code?
+              node.int_type? &&
+                !::Rack::Utils::SYMBOL_TO_STATUS_CODE.value?(node.source.to_i)
             end
           end
 

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rack/utils'
+
 module RuboCop
   module Cop
     module RSpec
@@ -29,13 +31,6 @@ module RuboCop
         #   it { is_expected.to have_http_status :error }
         #
         class HttpStatus < Cop
-          begin
-            require 'rack/utils'
-            RACK_LOADED = true
-          rescue LoadError
-            RACK_LOADED = false
-          end
-
           include ConfigurableEnforcedStyle
 
           def_node_matcher :http_status, <<-PATTERN
@@ -48,10 +43,6 @@ module RuboCop
               return unless checker.offensive?
               add_offense(checker.node, message: checker.message)
             end
-          end
-
-          def support_autocorrect?
-            RACK_LOADED
           end
 
           def autocorrect(node)
@@ -76,8 +67,6 @@ module RuboCop
           class SymbolicStyleChecker
             MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
                   'to describe HTTP status code.'.freeze
-            DEFAULT_MSG = 'Prefer `symbolic` over `numeric` ' \
-                  'to describe HTTP status code.'.freeze
 
             attr_reader :node
             def initialize(node)
@@ -89,11 +78,7 @@ module RuboCop
             end
 
             def message
-              if RACK_LOADED
-                format(MSG, prefer: preferred_style, current: number.to_s)
-              else
-                DEFAULT_MSG
-              end
+              format(MSG, prefer: preferred_style, current: number.to_s)
             end
 
             def preferred_style
@@ -115,8 +100,6 @@ module RuboCop
           class NumericStyleChecker
             MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
                   'to describe HTTP status code.'.freeze
-            DEFAULT_MSG = 'Prefer `numeric` over `symbolic` ' \
-                  'to describe HTTP status code.'.freeze
 
             WHITELIST_STATUS = %i[error success missing redirect].freeze
 
@@ -130,11 +113,7 @@ module RuboCop
             end
 
             def message
-              if RACK_LOADED
-                format(MSG, prefer: preferred_style, current: symbol.inspect)
-              else
-                DEFAULT_MSG
-              end
+              format(MSG, prefer: preferred_style, current: symbol.inspect)
             end
 
             def preferred_style

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -4,7 +4,11 @@ require_relative 'rspec/capybara/feature_methods'
 require_relative 'rspec/factory_bot/dynamic_attribute_defined_statically'
 require_relative 'rspec/factory_bot/static_attribute_defined_dynamically'
 
-require_relative 'rspec/rails/http_status'
+begin
+  require_relative 'rspec/rails/http_status'
+rescue LoadError # rubocop:disable Lint/HandleExceptions
+  # Rails/HttpStatus cannot be loaded if rack/utils is unavailable.
+end
 
 require_relative 'rspec/align_left_let_brace'
 require_relative 'rspec/align_right_let_brace'

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
       RUBY
     end
 
+    it 'does not register an offense when using custom HTTP code' do
+      expect_no_offenses(<<-RUBY)
+        it { is_expected.to have_http_status 550 }
+      RUBY
+    end
+
     include_examples 'autocorrect',
                      'it { is_expected.to have_http_status 200 }',
                      'it { is_expected.to have_http_status :ok }'

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -36,17 +36,6 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
                        'it { is_expected.to have_http_status(404) }',
                        'it { is_expected.to have_http_status(:not_found) }'
     end
-
-    context 'when rack is not loaded' do
-      before { stub_const("#{described_class}::RACK_LOADED", false) }
-
-      it 'registers an offense when using numeric value' do
-        expect_offense(<<-RUBY)
-          it { is_expected.to have_http_status 200 }
-                                               ^^^ Prefer `symbolic` over `numeric` to describe HTTP status code.
-        RUBY
-      end
-    end
   end
 
   context 'when EnforcedStyle is `numeric`' do
@@ -90,17 +79,6 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
       include_examples 'autocorrect',
                        'it { is_expected.to have_http_status(:not_found) }',
                        'it { is_expected.to have_http_status(404) }'
-    end
-
-    context 'when rack is not loaded' do
-      before { stub_const("#{described_class}::RACK_LOADED", false) }
-
-      it 'registers an offense when using numeric value' do
-        expect_offense(<<-RUBY)
-          it { is_expected.to have_http_status :ok }
-                                               ^^^ Prefer `numeric` over `symbolic` to describe HTTP status code.
-        RUBY
-      end
     end
   end
 end


### PR DESCRIPTION
Fixes #560.

When Rails/HttpStatus is configured to use `symbolic` style, a custom HTTP status code (e.g. 550) that couldn't be found in Rack's `SYMBOL_TO_STATUS_CODE` hash would result in an error:

    ^^^ Prefer `nil` over `550` to describe HTTP status code.

This is solved by allowing integer values that are *not* present in `SYMBOL_TO_STATUS_CODE` when using the `symbolic` stile.

For this to work, I found that the `Rails/HttpStatus` cop couldn’t continue to be flexible in its dependency on Rack. But we cannot allow rubocop-rspec to have a hard dependency on Rack either. So I’m suggesting that we `rescue LoadError` either in the cop itself, or in the rspec_cops.rb file, right after `require_relative 'rspec/rails/http_status'`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
