### PR TITLE
[FIX] False positive in `FactoryBot/DynamicAttributeDefinedStatically`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The `Rails/HttpStatus` cop is unavailable if the `rack` gem cannot be loaded. ([@bquorning][])
 * Fix `Rails/HttpStatus` not working with custom HTTP status codes. ([@bquorning][])
 * Fix `FactoryBot/StaticAttributeDefinedDynamically` to handle empty block. ([@abrom][])
+* Fix false positive in `FactoryBot/DynamicAttributeDefinedStatically` when a before/after callback has a symbol proc argument. ([@abrom][])
 
 ## 1.23.0 (2018-02-23)
 

--- a/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
@@ -59,6 +59,9 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
               recent_statuses [:published, :draft]
               meta_tags(like_count: 2)
               other_tags({ foo: nil })
+
+              before(:create, &:initialize_something)
+              after(:create, &:rebuild_cache)
             end
           end
         RUBY

--- a/spec/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::StaticAttributeDefinedDynamicall
               tag Tag::MAGIC
               recent_updates { [Time.current] }
               meta_tags { { first_like: Time.current } }
+              before(:create) { 'foo' }
             end
           end
         RUBY


### PR DESCRIPTION
When defining a before/after callback with a symbol proc argument, the dynamic attribute cop will incorrectly identify it as an offense:

```
before(:create, &:initialize_something)
after(:create, &:rebuild_cache)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
