### PR TITLE
[FIX] Handle empty block in FactoryBot/StaticAttributeDefinedDynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * The `Rails/HttpStatus` cop is unavailable if the `rack` gem cannot be loaded. ([@bquorning][])
 * Fix `Rails/HttpStatus` not working with custom HTTP status codes. ([@bquorning][])
+* Fix `FactoryBot/StaticAttributeDefinedDynamically` to handle empty block. ([@abrom][])
 
 ## 1.23.0 (2018-02-23)
 

--- a/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb
@@ -58,14 +58,20 @@ module RuboCop
           private
 
           def static?(node)
-            node.recursive_literal? || node.const_type?
+            node.nil? || node.recursive_literal? || node.const_type?
           end
 
           def autocorrected_source(node)
-            if node.body.hash_type?
-              "#{node.send_node.source}(#{node.body.source})"
+            "#{node.send_node.source}#{autocorrected_attribute(node.body)}"
+          end
+
+          def autocorrected_attribute(body)
+            if body.nil?
+              ' nil'
+            elsif body.hash_type?
+              "(#{body.source})"
             else
-              "#{node.send_node.source} #{node.body.source}"
+              ' ' + body.source
             end
           end
         end

--- a/spec/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::StaticAttributeDefinedDynamicall
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
               meta_tags { { foo: 1 } }
               ^^^^^^^^^^^^^^^^^^^^^^^^ Do not use a block to set a static value to an attribute.
+              title {}
+              ^^^^^^^^ Do not use a block to set a static value to an attribute.
             end
           end
         RUBY
@@ -78,6 +80,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::StaticAttributeDefinedDynamicall
             comments_count { 0 }
             type { User::MAGIC }
             description { nil }
+            title {}
             recent_statuses { [:published, :draft] }
             meta_tags { { foo: 1 } }
           end
@@ -90,6 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::StaticAttributeDefinedDynamicall
             comments_count 0
             type User::MAGIC
             description nil
+            title nil
             recent_statuses [:published, :draft]
             meta_tags({ foo: 1 })
           end


### PR DESCRIPTION
Fixes #563 

An empty attribute block would cause a null reference exception, and not identify it as an offense.

With this change, the following will be detected as an offense:
```
factory :foo do
  bar {}
end
```

and autocorrect it to:
```
factory :foo do
  bar nil
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
