### PR TITLE
Fix RuboCop v0.53.0 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,3 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
-
-# Awaiting bugfix: https://github.com/bbatsov/rubocop/issues/5224
-Layout/EmptyLinesAroundArguments:
-  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+* Compatibility with RuboCop v0.53.0. ([@bquorning][])
+
 ## Master (Unreleased)
 
 * The `Rails/HttpStatus` cop is unavailable if the `rack` gem cannot be loaded. ([@bquorning][])

--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -24,7 +24,7 @@ module RuboCop
           [Layout::ExtraSpacing]
         end
 
-        def investigate(_)
+        def investigate(_processed_source)
           token_aligner.offending_tokens.each do |let|
             add_offense(let, location: :begin)
           end

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -24,7 +24,7 @@ module RuboCop
           [Layout::ExtraSpacing]
         end
 
-        def investigate(_)
+        def investigate(_processed_source)
           token_aligner.offending_tokens.each do |let|
             add_offense(let, location: :end)
           end

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -107,7 +107,7 @@ module RuboCop
           File.fnmatch?("*#{glob}", processed_source.buffer.name)
         end
 
-        def relevant_rubocop_rspec_file?(_)
+        def relevant_rubocop_rspec_file?(_file)
           true
         end
       end

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -59,6 +59,7 @@ module RuboCop
       #   end
       class HookArgument < Cop
         include ConfigurableEnforcedStyle
+        include RangeHelp
 
         IMPLICIT_MSG = 'Omit the default `%<scope>p` ' \
                        'argument for RSpec hooks.'.freeze

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -27,6 +27,8 @@ module RuboCop
       #     end
       #   end
       class LeadingSubject < Cop
+        include RangeHelp
+
         MSG = 'Declare `subject` above any other `let` declarations.'.freeze
 
         def_node_matcher :subject?, '(block $(send nil? :subject ...) args ...)'

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -31,6 +31,8 @@ module RuboCop
       #     expect(some).to be
       #   end
       class LetBeforeExamples < Cop
+        include RangeHelp
+
         MSG = 'Move `let` before the examples in the group.'.freeze
 
         def_node_matcher :let?, '(block (send nil? {:let :let!} ...) ...)'

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -98,7 +98,7 @@ module RuboCop
 
         def_node_search :find_contexts, ExampleGroups::ALL.block_pattern
 
-        def on_top_level_describe(node, _)
+        def on_top_level_describe(node, _args)
           find_nested_contexts(node.parent) do |context, nesting|
             add_offense(
               context.children.first,

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -297,6 +297,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include InflectedHelper
         include ExplicitHelper
+        include RangeHelp
 
         def on_send(node)
           case style

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -105,7 +105,7 @@ module RuboCop
                             to_predicate_matcher(name) + args + block)
         end
 
-        def true?(to, matcher)
+        def true?(to_symbol, matcher)
           _recv, name, arg = *matcher
           result = case name
                    when :be, :eq
@@ -115,7 +115,7 @@ module RuboCop
                    when :be_falsey, :be_falsy, :a_falsey_value, :a_falsy_value
                      false
                    end
-          to == :to ? result : !result
+          to_symbol == :to ? result : !result
         end
       end
 
@@ -199,17 +199,17 @@ module RuboCop
 
         def autocorrect_explicit_block(node)
           predicate_matcher_block?(node) do |actual, matcher|
-            to, = *node
-            corrector_explicit(to, actual, matcher, to)
+            to_node, = *node
+            corrector_explicit(to_node, actual, matcher, to_node)
           end
         end
 
-        def corrector_explicit(to, actual, matcher, block_child)
+        def corrector_explicit(to_node, actual, matcher, block_child)
           lambda do |corrector|
-            replacement_matcher = replacement_matcher(to)
+            replacement_matcher = replacement_matcher(to_node)
             corrector.replace(matcher.loc.expression, replacement_matcher)
             move_predicate(corrector, actual, matcher, block_child)
-            corrector.replace(to.loc.selector, 'to')
+            corrector.replace(to_node.loc.selector, 'to')
           end
         end
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.52.1'
+  spec.add_runtime_dependency 'rubocop', '>= 0.53.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'rubocop/rspec/version'
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
RuboCop v0.53.0 has been released, and we were not completely compatible.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
